### PR TITLE
CLOUDP-84606: Atlas Operator Helm Chart

### DIFF
--- a/charts/atlas-operator-crds/Chart.yaml
+++ b/charts/atlas-operator-crds/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mongodb-atlas-operator-crds
 description: MongoDB Atlas Operator CRDs - Helm chart for installing and upgrading Custom Resource Definitions (CRDs) for the Atlas Operator.
 type: application
-version: 0.4.0
+version: 0.1.0
 appVersion: 0.4.0
 kubeVersion: ">=1.15.0-0"
 keywords:

--- a/charts/atlas-operator-crds/README.md
+++ b/charts/atlas-operator-crds/README.md
@@ -1,6 +1,6 @@
-# Atlas Operator CRDs Helm Chart
+# MongoDB Atlas Operator CRDs Helm Chart
 
-A Helm chart for installing and upgrading Custom Resource Definitions (CRDs) for the Atlas Operator. These CRDs are 
+A Helm chart for installing and upgrading Custom Resource Definitions (CRDs) for the [MongoDB Atlas Operator](https://github.com/mongodb/mongodb-atlas-kubernetes). These CRDs are 
 required by the Atlas Operator to work. 
 
 ## Usage

--- a/charts/atlas-operator/.helmignore
+++ b/charts/atlas-operator/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/atlas-operator/Chart.yaml
+++ b/charts/atlas-operator/Chart.yaml
@@ -3,7 +3,7 @@ name: mongodb-atlas-operator
 description: |-
   MongoDB Atlas Operator - a Helm chart for installing and upgrading Atlas Operator: the official Kubernetes operator allowing to manage MongoDB Atlas resources from Kubernetes
 type: application
-version: 0.4.0
+version: 0.1.0
 appVersion: 0.4.0
 kubeVersion: ">=1.15.0-0"
 keywords:

--- a/charts/atlas-operator/Chart.yaml
+++ b/charts/atlas-operator/Chart.yaml
@@ -1,6 +1,7 @@
 apiVersion: v2
-name: mongodb-atlas-operator-crds
-description: MongoDB Atlas Operator CRDs - Helm chart for installing and upgrading Custom Resource Definitions (CRDs) for the Atlas Operator.
+name: mongodb-atlas-operator
+description: |-
+  MongoDB Atlas Operator - a Helm chart for installing and upgrading Atlas Operator: the official Kubernetes operator allowing to manage MongoDB Atlas resources from Kubernetes
 type: application
 version: 0.4.0
 appVersion: 0.4.0

--- a/charts/atlas-operator/README.md
+++ b/charts/atlas-operator/README.md
@@ -1,0 +1,30 @@
+# MongoDB Atlas Operator Helm Chart
+
+A Helm chart for installing and upgrading [MongoDB Atlas Operator](https://github.com/mongodb/mongodb-atlas-kubernetes). 
+The Operator allows to manage resources from Atlas (projects, clusters, database users, etc) not leaving the Kubernetes cluster.
+
+## Prerequisites
+
+You need to install the [Atlas Operator CRDs](../atlas-operator-crds) first before installing the Operator.
+
+## Usage
+
+### Installing the Operator (in clusterwide mode) into the Kubernetes Cluster:
+
+```
+helm repo add mongodb https://mongodb.github.io/helm-charts
+helm install atlas-operator --namespace=atlas-operator --create-namespace mongodb/mongodb-atlas-operator
+```
+
+### Installing the Operator (in namespaced mode - watching the self namespace) into the Kubernetes Cluster:
+
+```
+helm repo add mongodb https://mongodb.github.io/helm-charts
+helm install atlas-operator --namespace=operator --set watchNamespaces=operator --create-namespace mongodb/mongodb-atlas-operator
+```
+
+### Upgrading the Operator:
+
+```
+helm upgrade mongodb-atlas-operator mongodb/mongodb-atlas-operator
+```

--- a/charts/atlas-operator/templates/NOTES.txt
+++ b/charts/atlas-operator/templates/NOTES.txt
@@ -1,0 +1,1 @@
+Thank you for installing {{ .Chart.Name }}.

--- a/charts/atlas-operator/templates/_helpers.tpl
+++ b/charts/atlas-operator/templates/_helpers.tpl
@@ -1,0 +1,140 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "mongodb-atlas-operator.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "mongodb-atlas-operator.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "mongodb-atlas-operator.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "mongodb-atlas-operator.labels" -}}
+helm.sh/chart: {{ include "mongodb-atlas-operator.chart" . }}
+{{ include "mongodb-atlas-operator.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "mongodb-atlas-operator.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "mongodb-atlas-operator.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "mongodb-atlas-operator.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "mongodb-atlas-operator.name" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+RBAC permissions
+*/}}
+{{- define "mongodb-atlas-operator.rbacRules" -}}
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - atlas.mongodb.com
+  resources:
+  - atlasclusters
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - atlas.mongodb.com
+  resources:
+  - atlasclusters/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - atlas.mongodb.com
+  resources:
+  - atlasdatabaseusers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - atlas.mongodb.com
+  resources:
+  - atlasdatabaseusers/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - atlas.mongodb.com
+  resources:
+  - atlasprojects
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - atlas.mongodb.com
+  resources:
+  - atlasprojects/status
+  verbs:
+  - get
+  - patch
+  - update
+{{- end -}}

--- a/charts/atlas-operator/templates/authproxy-service.yaml
+++ b/charts/atlas-operator/templates/authproxy-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "mongodb-atlas-operator.name" . }}-metrics-service
+  labels:
+    {{- include "mongodb-atlas-operator.labels" . | nindent 4 }}
+spec:
+  ports:
+    - name: https
+      port: 8443
+      targetPort: https
+  selector:
+    {{- include "mongodb-atlas-operator.selectorLabels" . | nindent 4 }}

--- a/charts/atlas-operator/templates/cluster-roles.yaml
+++ b/charts/atlas-operator/templates/cluster-roles.yaml
@@ -1,0 +1,65 @@
+{{- $operatorName := include "mongodb-atlas-operator.name" . -}}
+
+{{- if not .Values.watchNamespaces }}
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: "{{ $operatorName }}"
+  labels:
+  {{- include "mongodb-atlas-operator.labels" $ | nindent 4 }}
+rules:
+{{ template "mongodb-atlas-operator.rbacRules" $ | toYaml | indent 2 }}
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ $operatorName }}
+  labels:
+  {{- include "mongodb-atlas-operator.labels" $ | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ $operatorName }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "mongodb-atlas-operator.serviceAccountName" . }}
+    namespace: {{ $.Release.Namespace }}
+
+{{- end }}
+
+{{- /* It seems that the rbac-proxy role must be Cluster-scoped to handle requests from different namespaces?
+TODO May make sense in the future to configure a specific namespace where the prometheus server resides to give Role only to that namespace? */}}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: "{{ $.Release.Namespace }}-{{ $operatorName }}-proxy-role"
+  labels:
+  {{- include "mongodb-atlas-operator.labels" $ | nindent 4 }}
+rules:
+  - apiGroups: ["authentication.k8s.io"]
+    resources:
+      - tokenreviews
+    verbs: ["create"]
+  - apiGroups: ["authorization.k8s.io"]
+    resources:
+      - subjectaccessreviews
+    verbs: ["create"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: "{{ $.Release.Namespace }}-{{ $operatorName }}-proxy-role-binding"
+  labels:
+  {{- include "mongodb-atlas-operator.labels" $ | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: "{{ $.Release.Namespace }}-{{ $operatorName }}-proxy-role"
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "mongodb-atlas-operator.serviceAccountName" . }}
+    namespace: {{ $.Release.Namespace }}

--- a/charts/atlas-operator/templates/deployment.yaml
+++ b/charts/atlas-operator/templates/deployment.yaml
@@ -1,0 +1,94 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "mongodb-atlas-operator.name" . }}
+  labels:
+    {{- include "mongodb-atlas-operator.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "mongodb-atlas-operator.selectorLabels" . | nindent 6 }}
+  replicas: 1
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "mongodb-atlas-operator.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "mongodb-atlas-operator.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      terminationGracePeriodSeconds: 10
+      containers:
+        - args:
+          - --secure-listen-address=0.0.0.0:8443
+          - --upstream=http://127.0.0.1:8080/
+          - --logtostderr=true
+          - --v=10
+          image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+          name: kube-rbac-proxy
+          ports:
+            - containerPort: 8443
+              name: https
+        - name: manager
+          args:
+            - --atlas-domain={{ .Values.atlasURI }}
+            - --health-probe-bind-address=:8081
+            - --metrics-bind-address=127.0.0.1:8080
+            - --leader-elect
+          command:
+            - /manager
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+          {{- if .Values.watchNamespaces }}
+          - name: WATCHED_NAMESPACE
+            value: "{{- .Values.watchNamespaces }}"
+          {{- end }}
+          - name: OPERATOR_POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: OPERATOR_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8081
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8081
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/atlas-operator/templates/roles.yaml
+++ b/charts/atlas-operator/templates/roles.yaml
@@ -1,0 +1,106 @@
+{{- $operatorName := include "mongodb-atlas-operator.name" . -}}
+{{- $operatorNamespaceManaged := contains .Release.Namespace .Values.watchNamespaces -}}
+
+{{- /* so far we support only a single namespace but otherwise should iterate over the watchNamespaces */}}
+{{- if .Values.watchNamespaces }}
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: "{{ $operatorName }}"
+  namespace: {{ .Values.watchNamespaces }}
+  labels:
+  {{- include "mongodb-atlas-operator.labels" $ | nindent 4 }}
+rules:
+{{ template "mongodb-atlas-operator.rbacRules" $ | toYaml | indent 2 }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ $operatorName }}
+  namespace: {{ .Values.watchNamespaces }}
+  labels:
+  {{- include "mongodb-atlas-operator.labels" $ | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: "{{ $operatorName }}"
+subjects:
+  - kind: ServiceAccount
+    name: "{{ include "mongodb-atlas-operator.serviceAccountName" . }}"
+    namespace: {{ $.Release.Namespace }}
+
+{{- end }}
+
+{{- /* If operator namespace is not in the managed namespaces list, we need to give the same permissions to it in adition to above */}}
+{{- if not $operatorNamespaceManaged }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ $operatorName }}
+  labels:
+  {{- include "mongodb-atlas-operator.labels" $ | nindent 4 }}
+rules:
+{{ template "mongodb-atlas-operator.rbacRules" $ | toYaml | indent 2 }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: "{{ $operatorName }}"
+  labels:
+  {{- include "mongodb-atlas-operator.labels" $ | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: "{{ $operatorName }}"
+subjects:
+  - kind: ServiceAccount
+    name: "{{ include "mongodb-atlas-operator.serviceAccountName" . }}"
+    namespace: {{ $.Release.Namespace }}
+{{- end }}
+
+
+{{- /* we always create the leader election role - it doesn't need to be clusterwide */}}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: "{{ $operatorName }}-leader-election-role"
+rules:
+  - apiGroups:
+      - ""
+      - coordination.k8s.io
+    resources:
+      - configmaps
+      - leases
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: "{{ $operatorName }}-leader-election-rolebinding"
+  labels:
+  {{- include "mongodb-atlas-operator.labels" $ | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: "{{ $operatorName }}-leader-election-role"
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "mongodb-atlas-operator.serviceAccountName" . }}
+    namespace: {{ $.Release.Namespace }}

--- a/charts/atlas-operator/templates/serviceaccount.yaml
+++ b/charts/atlas-operator/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "mongodb-atlas-operator.serviceAccountName" . }}
+  labels:
+    {{- include "mongodb-atlas-operator.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/atlas-operator/values.yaml
+++ b/charts/atlas-operator/values.yaml
@@ -1,0 +1,56 @@
+# atlasURI is the URI of the MongoDB Atlas
+atlasURI: https://cloud.mongodb.com
+
+# watchNamespaces is the set of namespaces that are watched by the Operator.
+# The only possible values are:
+# - empty (watch all namespaces) or
+# - the name of the same namespace where the Operator is installed to.
+watchNamespaces:
+
+image:
+  repository: mongodb/mongodb-atlas-kubernetes-operator
+  pullPolicy: Always
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 2000
+
+securityContext:
+  allowPrivilegeEscalation: false
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+resources:
+  limits:
+    cpu: 500m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 50Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/charts/atlas-operator/values.yaml
+++ b/charts/atlas-operator/values.yaml
@@ -5,7 +5,7 @@ atlasURI: https://cloud.mongodb.com
 # The only possible values are:
 # - empty (watch all namespaces) or
 # - the name of the same namespace where the Operator is installed to.
-watchNamespaces:
+watchNamespaces: ""
 
 image:
   repository: mongodb/mongodb-atlas-kubernetes-operator
@@ -34,12 +34,6 @@ podSecurityContext:
 
 securityContext:
   allowPrivilegeEscalation: false
-  # capabilities:
-  #   drop:
-  #   - ALL
-  # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-  # runAsUser: 1000
 
 resources:
   limits:


### PR DESCRIPTION
This PR adds the Atlas Operator Helm chart.
Initially it was generated by `helm create` and adjusted after that.
The helm chart supports the `clusterwide` mode and `namespaced` (self-namespace only) modes:

```
# clusterwide
helm install atlas-operator --namespace=operator --create-namespace 

# namespaced
helm install atlas-operator --namespace=operator --set watchNamespaces=operator --create-namespace

```

Testing was done: https://docs.google.com/document/d/1PH5kYHLZ-2ZnorytzGukhkR8NCIP79m8iAiN9zKwok8/edit?usp=sharing