### PR TITLE
Fixing typo error charts/README.ms

### DIFF
--- a/charts/README.md
+++ b/charts/README.md
@@ -2,7 +2,8 @@
 
 Please note that Database and OpsManager include an operator as a dependency. There is no need to install is separately.
 
-```helm repo add mongodb https://github.io/mongodb/helm-charts```
+```helm repo add mongodb https://mongodb.github.io/helm-charts```
+
 ```helm dependency  update```
 
 In order to install Ops Manager run this command


### PR DESCRIPTION
Fixing the typo error in helm_charts\charts\README.md 


The original URL is not a valid chart repository
```
| ==> helm repo add mongodb https://github.io/mongodb/helm-charts
Error: looks like "https://github.io/mongodb/helm-charts" is not a valid chart repository or cannot be reached: error unmarshaling JSON: while decoding JSON: json: cannot unmarshal string into Go value of type repo.IndexFile
```