### PR TITLE
feat: Allow to granularly disable reconcilers with Helm values

### DIFF
--- a/charts/atlas-operator/templates/deployment.yaml
+++ b/charts/atlas-operator/templates/deployment.yaml
@@ -56,6 +56,18 @@ spec:
           - name: WATCH_NAMESPACE
             value: "{{- .Values.watchNamespaces }}"
           {{- end }}
+          {{- if .Values.disableAtlasClusterReconciler }}
+          - name: DISABLE_ATLAS_CLUSTER_RECONCILER
+            value: "{{- .Values.disableAtlasClusterReconciler }}"
+          {{- end }}
+          {{- if .Values.disableAtlasProjectReconciler }}
+          - name: DISABLE_ATLAS_PROJECT_RECONCILER
+            value: "{{- .Values.disableAtlasProjectReconciler }}"
+          {{- end }}
+          {{- if .Values.disableAtlasDatabaseUserReconciler }}
+          - name: DISABLE_ATLAS_DATABASE_USER_RECONCILER
+            value: "{{- .Values.disableAtlasDatabaseUserReconciler }}"
+          {{- end }}
           - name: OPERATOR_POD_NAME
             valueFrom:
               fieldRef:

--- a/charts/atlas-operator/values.yaml
+++ b/charts/atlas-operator/values.yaml
@@ -19,6 +19,11 @@ globalConnectionSecret:
 # - the name of the same namespace where the Operator is installed to.
 watchNamespaces: ""
 
+# Allow to granularly disable reconcilers. Uncomment to disable
+# disableAtlasClusterReconciler: "true"
+# disableAtlasProjectReconciler: "true"
+# disableAtlasDatabaseUserReconciler: "true"
+
 image:
   repository: mongodb/mongodb-atlas-kubernetes-operator
   pullPolicy: Always


### PR DESCRIPTION
The story and implementation are inside issue [#271](https://github.com/mongodb/mongodb-atlas-kubernetes/issues/271)