### PR TITLE
Support multiple clusters per project creation; support existing k8s secrets with Atlas API keys

### DIFF
--- a/charts/atlas-cluster/Chart.yaml
+++ b/charts/atlas-cluster/Chart.yaml
@@ -16,4 +16,3 @@ appVersion: "0.5.0"
 maintainers:
   - name: MongoDB
     email: support@mongodb.com
-home: https://github.com/mongodb/mongodb-atlas-kubernetes

--- a/charts/atlas-cluster/Chart.yaml
+++ b/charts/atlas-cluster/Chart.yaml
@@ -4,15 +4,14 @@ description: A Helm chart to manage Atlas resources with Atlas operator
 
 type: application
 
-# This is the chart version. This version number should be incremented each time you make changes
-# to the chart and its templates, including the app version.
-# Versions are expected to follow Semantic Versioning (https://semver.org/)
 version: 0.1.6
 
-# This is the version number of the application being deployed. This version number should be
-# incremented each time you make changes to the application. Versions are not expected to
-# follow Semantic Versioning. They should reflect the version the application is using.
-# It is recommended to use it with quotes.
+keywords:
+- mongodb
+- database
+- nosql
+home: https://github.com/mongodb/mongodb-enterprise-kubernetes
+icon: https://camo.githubusercontent.com/d473c25e361fb2206f06bdcf24028e8d52bc30d1/68747470733a2f2f6d6f6e676f64622d6b756265726e657465732d6f70657261746f722e73332e616d617a6f6e6177732e636f6d2f696d672f4c6561662d466f7265737425343032782e706e67
 appVersion: "0.5.0"
 maintainers:
   - name: MongoDB

--- a/charts/atlas-cluster/templates/atlas-cluster.yaml
+++ b/charts/atlas-cluster/templates/atlas-cluster.yaml
@@ -1,65 +1,68 @@
+{{- range .Values.clusters }}
+---
 apiVersion: atlas.mongodb.com/v1
 kind: AtlasCluster
 metadata:
-  name: {{ include "atlas-cluster.fullname" . }}
+  name: {{ .name }}
   labels:
-    {{- include "atlas-cluster.labels" . | nindent 4 }}
-  namespace: {{ .Release.Namespace }} 
+    {{- include "atlas-cluster.labels" $ | nindent 4 }}
+  namespace: {{ $.Release.Namespace }}
 spec:
-  name: {{ include "atlas-cluster.fullname" . }}
+  name: {{ .name }}
   projectRef:
-    name: {{ include "atlas-cluster.projectfullname" . }}
+    name: {{ include "atlas-cluster.projectfullname" $ }}
   providerSettings:
-{{- with .Values.mongodb.providerSettings }}
+{{- with .providerSettings }}
 {{- toYaml . | nindent 4 }}
 {{- end }}
-{{- if .Values.mongodb.autoScaling }}
+{{- if .autoScaling }}
   autoScaling:
-{{- with .Values.mongodb.autoScaling }}  
+{{- with .autoScaling }}
 {{- toYaml . | nindent 4 }}
 {{- end }}
 {{- end }}
-{{- if .Values.mongodb.autoIndexingEnabled }}
+{{- if .autoIndexingEnabled }}
     autoIndexingEnabled: false
 {{- end }}
-{{- if .Values.mongodb.biConnector }}  
+{{- if .biConnector }}
   biConnector:
-    enabled: {{ .Values.mongodb.biConnector.enabled }}
-    readPreference: {{ .Values.mongodb.biConnector.readPreference }}
+    enabled: {{ .biConnector.enabled }}
+    readPreference: {{ .biConnector.readPreference }}
 {{- end }}
-{{- if .Values.mongodb.clusterType }}  
-  clusterType: {{ .Values.mongodb.clusterType }}
+{{- if .clusterType }}
+  clusterType: {{ .clusterType }}
 {{- end }}
-{{- if .Values.mongodb.diskSizeGB }}  
-  diskSizeGB: {{ .Values.mongodb.diskSizeGB }}
+{{- if .diskSizeGB }}
+  diskSizeGB: {{ .diskSizeGB }}
 {{- end }}
-{{- if .Values.mongodb.encryptionAtRestProvider }}  
-  encryptionAtRestProvider: {{ .Values.mongodb.encryptionAtRestProvider }}
+{{- if .encryptionAtRestProvider }}
+  encryptionAtRestProvider: {{ .encryptionAtRestProvider }}
 {{- end }}
-{{- if .Values.mongodb.labels }}  
+{{- if .labels }}
   labels:
-  {{- with .Values.mongodb.labels }}  
+  {{- with .labels }}
   {{- toYaml . | nindent 4 }}
   {{- end }}
 {{- end }}
-{{- if .Values.mongodb.mongoDBMajorVersion }}  
-  mongoDBMajorVersion: {{ .Values.mongodb.mongoDBMajorVersion }}
+{{- if .mongoDBMajorVersion }}
+  mongoDBMajorVersion: {{ .mongoDBMajorVersion }}
 {{- end }}
-{{- if .Values.mongodb.numShards }}  
-  numShards: {{ .Values.mongodb.numShards }}
+{{- if .numShards }}
+  numShards: {{ .numShards }}
 {{- end }}
-{{- if .Values.mongodb.paused }}  
-  paused: {{ .Values.mongodb.paused }}
+{{- if .paused }}
+  paused: {{ .paused }}
 {{- end }}
-{{- if .Values.mongodb.pitEnabled }}  
-  pitEnabled: {{ .Values.mongodb.pitEnabled }}
+{{- if .pitEnabled }}
+  pitEnabled: {{ .pitEnabled }}
 {{- end }}
-{{- if .Values.mongodb.providerBackupEnabled }}  
-  providerBackupEnabled: {{ .Values.mongodb.providerBackupEnabled }}
+{{- if .providerBackupEnabled }}
+  providerBackupEnabled: {{ .providerBackupEnabled }}
 {{- end }}
-{{- if .Values.mongodb.replicationSpecs }}  
+{{- if .replicationSpecs }}
   replicationSpecs:
-  {{- with .Values.mongodb.replicationSpecs }}  
+  {{- with .replicationSpecs }}
   {{- toYaml . | nindent 4 }}
   {{- end }}
+{{- end }}
 {{- end }}

--- a/charts/atlas-cluster/templates/atlas-cluster.yaml
+++ b/charts/atlas-cluster/templates/atlas-cluster.yaml
@@ -7,6 +7,10 @@ metadata:
   labels:
     {{- include "atlas-cluster.labels" $ | nindent 4 }}
   namespace: {{ $.Release.Namespace }}
+  {{- if .annotations }}
+  annotations:
+{{ toYaml .annotations | indent 4 }}
+  {{- end }}
 spec:
   name: {{ .name }}
   projectRef:

--- a/charts/atlas-cluster/templates/atlas-mongodb-user-secret.yaml
+++ b/charts/atlas-cluster/templates/atlas-mongodb-user-secret.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.project.create }}
 {{- range .Values.users }}
 ---
 apiVersion: v1
@@ -10,4 +11,5 @@ metadata:
 type: Opaque
 stringData:
   password: {{ .password | quote }}
+{{- end }}
 {{- end }}

--- a/charts/atlas-cluster/templates/atlas-mongodb-user.yaml
+++ b/charts/atlas-cluster/templates/atlas-mongodb-user.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.project.create }}
 {{- range .Values.users }}
 ---
 apiVersion: atlas.mongodb.com/v1
@@ -27,4 +28,5 @@ spec:
   scopes:
     {{- toYaml .scopes | nindent 4 }}
   {{- end }}
+{{- end }}
 {{- end }}

--- a/charts/atlas-cluster/templates/atlas-project.yaml
+++ b/charts/atlas-cluster/templates/atlas-project.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.project.create }}
 apiVersion: atlas.mongodb.com/v1
 kind: AtlasProject
 metadata:
@@ -24,3 +25,4 @@ spec:
   {{- with .Values.project.projectIpAccessList }}
   {{- toYaml . | nindent 2 }}
   {{- end }}
+{{- end }}

--- a/charts/atlas-cluster/templates/atlas-project.yaml
+++ b/charts/atlas-cluster/templates/atlas-project.yaml
@@ -7,11 +7,16 @@ metadata:
     {{- include "atlas-cluster.labels" . | nindent 4 }}
   annotations:
     'helm.sh/hook': post-delete,pre-install,pre-upgrade
+  {{- if .Values.project.annotations }}
+{{ toYaml .Values.project.annotations | indent 4 }}
+  {{- end }}
 spec:
   name: {{ .Values.project.atlasProjectName }}
   connectionSecretRef:
 {{- if .Values.atlas.connectionSecretName }}
     name: {{ .Values.atlas.connectionSecretName}}
+{{- else if and (not .Values.atlas.create) .Values.atlas.existingSecretName  }}
+    name: {{ .Values.atlas.existingSecretName }}
 {{- else }}
     name: {{ include "atlas-cluster.fullname" . }}-secret
 {{- end }}

--- a/charts/atlas-cluster/templates/atlas-secret.yaml
+++ b/charts/atlas-cluster/templates/atlas-secret.yaml
@@ -1,5 +1,4 @@
 {{- if .Values.atlas.create }}
-----
 apiVersion: v1
 kind: Secret
 type: Opaque

--- a/charts/atlas-cluster/templates/atlas-secret.yaml
+++ b/charts/atlas-cluster/templates/atlas-secret.yaml
@@ -1,4 +1,5 @@
 ---
+{{- if .Values.atlas.create }}
 apiVersion: v1
 kind: Secret
 type: Opaque
@@ -17,4 +18,4 @@ data:
     orgId: {{ .Values.atlas.orgId| b64enc }}
     publicApiKey: {{ .Values.atlas.publicApiKey| b64enc }}
     privateApiKey: {{ .Values.atlas.privateApiKey| b64enc }}
-    
+{{- end }}

--- a/charts/atlas-cluster/templates/atlas-secret.yaml
+++ b/charts/atlas-cluster/templates/atlas-secret.yaml
@@ -1,5 +1,5 @@
----
 {{- if .Values.atlas.create }}
+----
 apiVersion: v1
 kind: Secret
 type: Opaque

--- a/charts/atlas-cluster/values.yaml
+++ b/charts/atlas-cluster/values.yaml
@@ -3,6 +3,8 @@ mongodb-atlas-operator:
 
 # Please provide Atlas API credentials and Organization
 atlas:
+  create: true
+  existingSecretName: ""
   orgId: "<Atlas Organization ID>"
   publicApiKey: "<Atlas_api_public_key>"
   privateApiKey: "<Atlas_api_private_key>"
@@ -12,6 +14,8 @@ atlas:
 project:
   name: my-project
   atlasProjectName: "Test Project"
+  annotations: {}
+    # mongodb.com/atlas-resource-policy: keep
   # fullnameOverride: ""
 
   projectIpAccessList:
@@ -22,11 +26,14 @@ project:
 
 clusters:
   - name: cluster-name
+    annotations: {}
+      # mongodb.com/atlas-resource-policy: keep
     providerSettings:
       instanceSizeName: M2
       providerName: TENANT
       backingProviderName: AWS
       regionName: US_EAST_1
+
 # Optional section. for more information visit
 # https://docs.atlas.mongodb.com/reference/api/clusters-create-one/
 # #

--- a/charts/atlas-cluster/values.yaml
+++ b/charts/atlas-cluster/values.yaml
@@ -12,6 +12,7 @@ atlas:
   connectionSecretName: ""
 
 project:
+  create: true
   name: my-project
   atlasProjectName: "Test Project"
   annotations: {}

--- a/charts/atlas-cluster/values.yaml
+++ b/charts/atlas-cluster/values.yaml
@@ -20,10 +20,8 @@ project:
   # fullnameOverride: ""
 
   projectIpAccessList:
-    - ipAddress: "192.0.2.15"
-      comment: "IP address for Application Server A"
-    - ipAddress: "203.0.113.0/24"
-      comment: "CIDR block for Application Server B - D"
+    - ipAddress: "0.0.0.0/1"
+      comment: "REMOVE ME"
 
 clusters:
   - name: cluster-name

--- a/charts/atlas-cluster/values.yaml
+++ b/charts/atlas-cluster/values.yaml
@@ -20,13 +20,13 @@ project:
     - ipAddress: "203.0.113.0/24"
       comment: "CIDR block for Application Server B - D"
 
-mongodb:
-  providerSettings:
-    instanceSizeName: M2
-    providerName: TENANT
-    backingProviderName: AWS
-    regionName: US_EAST_1
-
+clusters:
+  - name: cluster-name
+    providerSettings:
+      instanceSizeName: M2
+      providerName: TENANT
+      backingProviderName: AWS
+      regionName: US_EAST_1
 # Optional section. for more information visit
 # https://docs.atlas.mongodb.com/reference/api/clusters-create-one/
 # #

--- a/charts/atlas-operator-crds/Chart.yaml
+++ b/charts/atlas-operator-crds/Chart.yaml
@@ -12,6 +12,7 @@ keywords:
   - cluster
   - nosql
 home: https://github.com/mongodb/mongodb-atlas-kubernetes
+icon: https://camo.githubusercontent.com/d473c25e361fb2206f06bdcf24028e8d52bc30d1/68747470733a2f2f6d6f6e676f64622d6b756265726e657465732d6f70657261746f722e73332e616d617a6f6e6177732e636f6d2f696d672f4c6561662d466f7265737425343032782e706e67
 maintainers:
   - name: MongoDB
     email: support@mongodb.com

--- a/charts/atlas-operator/Chart.yaml
+++ b/charts/atlas-operator/Chart.yaml
@@ -13,6 +13,7 @@ keywords:
   - cluster
   - nosql
 home: https://github.com/mongodb/mongodb-atlas-kubernetes
+icon: https://camo.githubusercontent.com/d473c25e361fb2206f06bdcf24028e8d52bc30d1/68747470733a2f2f6d6f6e676f64622d6b756265726e657465732d6f70657261746f722e73332e616d617a6f6e6177732e636f6d2f696d672f4c6561662d466f7265737425343032782e706e67
 maintainers:
   - name: MongoDB
     email: support@mongodb.com

--- a/charts/atlas-operator/templates/cluster-roles.yaml
+++ b/charts/atlas-operator/templates/cluster-roles.yaml
@@ -28,38 +28,3 @@ subjects:
     namespace: {{ $.Release.Namespace }}
 
 {{- end }}
-
-{{- /* It seems that the rbac-proxy role must be Cluster-scoped to handle requests from different namespaces?
-TODO May make sense in the future to configure a specific namespace where the prometheus server resides to give Role only to that namespace? */}}
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: "{{ $.Release.Namespace }}-{{ $operatorName }}-proxy-role"
-  labels:
-  {{- include "mongodb-atlas-operator.labels" $ | nindent 4 }}
-rules:
-  - apiGroups: ["authentication.k8s.io"]
-    resources:
-      - tokenreviews
-    verbs: ["create"]
-  - apiGroups: ["authorization.k8s.io"]
-    resources:
-      - subjectaccessreviews
-    verbs: ["create"]
-
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: "{{ $.Release.Namespace }}-{{ $operatorName }}-proxy-role-binding"
-  labels:
-  {{- include "mongodb-atlas-operator.labels" $ | nindent 4 }}
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: "{{ $.Release.Namespace }}-{{ $operatorName }}-proxy-role"
-subjects:
-  - kind: ServiceAccount
-    name: {{ include "mongodb-atlas-operator.serviceAccountName" . }}
-    namespace: {{ $.Release.Namespace }}

--- a/charts/atlas-operator/templates/deployment.yaml
+++ b/charts/atlas-operator/templates/deployment.yaml
@@ -27,24 +27,12 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       terminationGracePeriodSeconds: 10
       containers:
-        - args:
-          - --secure-listen-address=0.0.0.0:8443
-          - --upstream=http://127.0.0.1:8080/
-          - --logtostderr=true
-          - --v=10
-          image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
-          name: kube-rbac-proxy
-          ports:
-            - containerPort: 8443
-              name: https
-          securityContext:
-          {{- toYaml .Values.securityContext | nindent 12 }}
         - name: manager
           args:
             - --atlas-domain={{ .Values.atlasURI }}
-            - --health-probe-bind-address=:8081
-            - --metrics-bind-address=127.0.0.1:8080
-            - --leader-elect
+            - "--health-probe-bind-address=:8081"
+            - "--metrics-bind-address=127.0.0.1:8080"
+            - "--leader-elect"
           command:
             - /manager
           securityContext:

--- a/charts/community-database/Chart.yaml
+++ b/charts/community-database/Chart.yaml
@@ -1,0 +1,18 @@
+apiVersion: v2
+name: community-operator
+description: |-
+  MongoDB Community Operator - a Helm chart for installing and upgrading Community Operator: the official Kubernetes operator allowing to manage MongoDB Community resources from Kubernetes
+type: application
+version: 0.1.0
+appVersion: 0.6.1
+kubeVersion: ">=1.15.0-0"
+keywords:
+  - mongodb
+  - community
+  - database
+  - cluster
+  - nosql
+home: https://github.com/mongodb/mongodb-kubernetes-operator
+maintainers:
+  - name: MongoDB
+    email: support@mongodb.com

--- a/charts/community-database/Chart.yaml
+++ b/charts/community-database/Chart.yaml
@@ -13,6 +13,7 @@ keywords:
   - cluster
   - nosql
 home: https://github.com/mongodb/mongodb-kubernetes-operator
+icon: https://camo.githubusercontent.com/d473c25e361fb2206f06bdcf24028e8d52bc30d1/68747470733a2f2f6d6f6e676f64622d6b756265726e657465732d6f70657261746f722e73332e616d617a6f6e6177732e636f6d2f696d672f4c6561662d466f7265737425343032782e706e67
 maintainers:
   - name: MongoDB
     email: support@mongodb.com

--- a/charts/community-database/templates/database.yaml
+++ b/charts/community-database/templates/database.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: mongodbcommunity.mongodb.com/v1
+kind: MongoDBCommunity
+metadata:
+  name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  members: 3
+  type: ReplicaSet
+  version: "{{ .Values.mongodbVersion }}"
+  security:
+    authentication:
+      modes: ["SCRAM"]
+  users:
+    - name: {{ .Values.mongodbUsername }} 
+      db: admin
+      passwordSecretRef: # a reference to the secret that will be used to generate the user's password
+        name: {{ .Release.Name }}-mongodb-user-password
+      roles:
+        - name: clusterAdmin
+          db: admin
+        - name: userAdminAnyDatabase
+          db: admin
+        - name: readWriteAnyDatabase
+          db: admin
+      scramCredentialsSecretName: {{ .Release.Name }}-mongodb-scram-salt
+  additionalMongodConfig:
+    storage.wiredTiger.engineConfig.journalCompressor: zlib
+

--- a/charts/community-database/templates/mongodb-user-password.yaml
+++ b/charts/community-database/templates/mongodb-user-password.yaml
@@ -1,0 +1,11 @@
+# the user credentials will be generated from this secret
+# once the credentials are generated, this secret is no longer required
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Release.Name }}-mongodb-user-password
+  namespace: {{ .Release.Namespace }}
+type: Opaque
+stringData:
+  password: {{ .Values.mongodbUserPassword }} 

--- a/charts/community-database/values.yaml
+++ b/charts/community-database/values.yaml
@@ -1,4 +1,3 @@
 mongodbVersion: "4.4.5"
 mongodbUsername: admin
 mongodbUserPassword: testing1234!
-

--- a/charts/community-database/values.yaml
+++ b/charts/community-database/values.yaml
@@ -1,0 +1,4 @@
+mongodbVersion: "4.4.5"
+mongodbUsername: admin
+mongodbUserPassword: testing1234!
+

--- a/charts/community-operator/.helmignore
+++ b/charts/community-operator/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/community-operator/Chart.yaml
+++ b/charts/community-operator/Chart.yaml
@@ -1,0 +1,18 @@
+apiVersion: v2
+name: community-operator
+description: |-
+  MongoDB Community Operator - a Helm chart for installing and upgrading Community Operator: the official Kubernetes operator allowing to manage MongoDB Community resources from Kubernetes
+type: application
+version: 0.1.0
+appVersion: 0.6.1
+kubeVersion: ">=1.15.0-0"
+keywords:
+  - mongodb
+  - community
+  - database
+  - cluster
+  - nosql
+home: https://github.com/mongodb/mongodb-kubernetes-operator
+maintainers:
+  - name: MongoDB
+    email: support@mongodb.com

--- a/charts/community-operator/Chart.yaml
+++ b/charts/community-operator/Chart.yaml
@@ -13,6 +13,7 @@ keywords:
   - cluster
   - nosql
 home: https://github.com/mongodb/mongodb-kubernetes-operator
+icon: https://camo.githubusercontent.com/d473c25e361fb2206f06bdcf24028e8d52bc30d1/68747470733a2f2f6d6f6e676f64622d6b756265726e657465732d6f70657261746f722e73332e616d617a6f6e6177732e636f6d2f696d672f4c6561662d466f7265737425343032782e706e67
 maintainers:
   - name: MongoDB
     email: support@mongodb.com

--- a/charts/community-operator/crds/mongodbcommunity.mongodb.com_mongodbcommunity.yaml
+++ b/charts/community-operator/crds/mongodbcommunity.mongodb.com_mongodbcommunity.yaml
@@ -1,0 +1,329 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.1
+  creationTimestamp: null
+  name: mongodbcommunity.mongodbcommunity.mongodb.com
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.phase
+    description: Current state of the MongoDB deployment
+    name: Phase
+    type: string
+  - JSONPath: .status.version
+    description: Version of MongoDB server
+    name: Version
+    type: string
+  group: mongodbcommunity.mongodb.com
+  names:
+    kind: MongoDBCommunity
+    listKind: MongoDBCommunityList
+    plural: mongodbcommunity
+    shortNames:
+    - mdbc
+    singular: mongodbcommunity
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: MongoDBCommunity is the Schema for the mongodbs API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: MongoDBCommunitySpec defines the desired state of MongoDB
+          properties:
+            additionalMongodConfig:
+              description: 'AdditionalMongodConfig is additional configuration that
+                can be passed to each data-bearing mongod at runtime. Uses the same
+                structure as the mongod configuration file: https://docs.mongodb.com/manual/reference/configuration-options/'
+              nullable: true
+              type: object
+            featureCompatibilityVersion:
+              description: FeatureCompatibilityVersion configures the feature compatibility
+                version that will be set for the deployment
+              type: string
+            members:
+              description: Members is the number of members in the replica set
+              type: integer
+            replicaSetHorizons:
+              description: ReplicaSetHorizons Add this parameter and values if you
+                need your database to be accessed outside of Kubernetes. This setting
+                allows you to provide different DNS settings within the Kubernetes
+                cluster and to the Kubernetes cluster. The Kubernetes Operator uses
+                split horizon DNS for replica set members. This feature allows communication
+                both within the Kubernetes cluster and from outside Kubernetes.
+              items:
+                additionalProperties:
+                  type: string
+                type: object
+              type: array
+            security:
+              description: Security configures security features, such as TLS, and
+                authentication settings for a deployment
+              properties:
+                authentication:
+                  properties:
+                    ignoreUnknownUsers:
+                      nullable: true
+                      type: boolean
+                    modes:
+                      description: Modes is an array specifying which authentication
+                        methods should be enabled.
+                      items:
+                        enum:
+                        - SCRAM
+                        type: string
+                      type: array
+                  required:
+                  - modes
+                  type: object
+                roles:
+                  description: User-specified custom MongoDB roles that should be
+                    configured in the deployment.
+                  items:
+                    description: CustomRole defines a custom MongoDB role.
+                    properties:
+                      authenticationRestrictions:
+                        description: The authentication restrictions the server enforces
+                          on the role.
+                        items:
+                          description: AuthenticationRestriction specifies a list
+                            of IP addresses and CIDR ranges users are allowed to connect
+                            to or from.
+                          properties:
+                            clientSource:
+                              items:
+                                type: string
+                              type: array
+                            serverAddress:
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - clientSource
+                          - serverAddress
+                          type: object
+                        type: array
+                      db:
+                        description: The database of the role.
+                        type: string
+                      privileges:
+                        description: The privileges to grant the role.
+                        items:
+                          description: Privilege defines the actions a role is allowed
+                            to perform on a given resource.
+                          properties:
+                            actions:
+                              items:
+                                type: string
+                              type: array
+                            resource:
+                              description: Resource specifies specifies the resources
+                                upon which a privilege permits actions. See https://docs.mongodb.com/manual/reference/resource-document
+                                for more.
+                              properties:
+                                anyResource:
+                                  type: boolean
+                                cluster:
+                                  type: boolean
+                                collection:
+                                  type: string
+                                db:
+                                  type: string
+                              type: object
+                          required:
+                          - actions
+                          - resource
+                          type: object
+                        type: array
+                      role:
+                        description: The name of the role.
+                        type: string
+                      roles:
+                        description: An array of roles from which this role inherits
+                          privileges.
+                        items:
+                          description: Role is the database role this user should
+                            have
+                          properties:
+                            db:
+                              description: DB is the database the role can act on
+                              type: string
+                            name:
+                              description: Name is the name of the role
+                              type: string
+                          required:
+                          - db
+                          - name
+                          type: object
+                        type: array
+                    required:
+                    - db
+                    - privileges
+                    - role
+                    type: object
+                  type: array
+                tls:
+                  description: TLS configuration for both client-server and server-server
+                    communication
+                  properties:
+                    caConfigMapRef:
+                      description: CaConfigMap is a reference to a ConfigMap containing
+                        the certificate for the CA which signed the server certificates
+                        The certificate is expected to be available under the key
+                        "ca.crt"
+                      properties:
+                        name:
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    certificateKeySecretRef:
+                      description: CertificateKeySecret is a reference to a Secret
+                        containing a private key and certificate to use for TLS. The
+                        key and cert are expected to be PEM encoded and available
+                        at "tls.key" and "tls.crt". This is the same format used for
+                        the standard "kubernetes.io/tls" Secret type, but no specific
+                        type is required.
+                      properties:
+                        name:
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    enabled:
+                      type: boolean
+                    optional:
+                      description: Optional configures if TLS should be required or
+                        optional for connections
+                      type: boolean
+                  required:
+                  - enabled
+                  type: object
+              type: object
+            statefulSet:
+              description: StatefulSetConfiguration holds the optional custom StatefulSet
+                that should be merged into the operator created one.
+              properties:
+                spec:
+                  type: object
+              required:
+              - spec
+              type: object
+            type:
+              description: Type defines which type of MongoDB deployment the resource
+                should create
+              enum:
+              - ReplicaSet
+              type: string
+            users:
+              description: Users specifies the MongoDB users that should be configured
+                in your deployment
+              items:
+                properties:
+                  db:
+                    description: DB is the database the user is stored in. Defaults
+                      to "admin"
+                    type: string
+                  name:
+                    description: Name is the username of the user
+                    type: string
+                  passwordSecretRef:
+                    description: PasswordSecretRef is a reference to the secret containing
+                      this user's password
+                    properties:
+                      key:
+                        description: Key is the key in the secret storing this password.
+                          Defaults to "password"
+                        type: string
+                      name:
+                        description: Name is the name of the secret storing this user's
+                          password
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  roles:
+                    description: Roles is an array of roles assigned to this user
+                    items:
+                      description: Role is the database role this user should have
+                      properties:
+                        db:
+                          description: DB is the database the role can act on
+                          type: string
+                        name:
+                          description: Name is the name of the role
+                          type: string
+                      required:
+                      - db
+                      - name
+                      type: object
+                    type: array
+                  scramCredentialsSecretName:
+                    description: ScramCredentialsSecretName appended by string "scram-credentials"
+                      is the name of the secret object created by the mongoDB operator
+                      for storing SCRAM credentials
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                required:
+                - name
+                - passwordSecretRef
+                - roles
+                - scramCredentialsSecretName
+                type: object
+              type: array
+            version:
+              description: Version defines which version of MongoDB will be used
+              type: string
+          required:
+          - security
+          - type
+          - users
+          - version
+          type: object
+        status:
+          description: MongoDBCommunityStatus defines the observed state of MongoDB
+          properties:
+            currentMongoDBMembers:
+              type: integer
+            currentStatefulSetReplicas:
+              type: integer
+            message:
+              type: string
+            mongoUri:
+              type: string
+            phase:
+              type: string
+          required:
+          - currentMongoDBMembers
+          - currentStatefulSetReplicas
+          - mongoUri
+          - phase
+          type: object
+      type: object
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/charts/community-operator/templates/NOTES.txt
+++ b/charts/community-operator/templates/NOTES.txt
@@ -1,0 +1,2 @@
+MongoDB Rocks!
+

--- a/charts/community-operator/templates/manager.yaml
+++ b/charts/community-operator/templates/manager.yaml
@@ -1,0 +1,43 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        name: {{ .Release.Name }}
+    spec:
+      containers:
+      - command:
+        - /usr/local/bin/entrypoint
+        env:
+        - name: WATCH_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: OPERATOR_NAME
+          value: mongodb-kubernetes-operator
+        - name: AGENT_IMAGE
+          value: quay.io/mongodb/mongodb-agent:10.29.0.6830-1
+        - name: VERSION_UPGRADE_HOOK_IMAGE
+          value: quay.io/mongodb/mongodb-kubernetes-operator-version-upgrade-post-start-hook:1.0.2
+        - name: READINESS_PROBE_IMAGE
+          value: quay.io/mongodb/mongodb-kubernetes-readinessprobe:1.0.4
+        - name: MONGODB_IMAGE
+          value: library/mongo
+        - name: MONGODB_REPO_URL
+          value: registry.hub.docker.com
+        image: quay.io/mongodb/mongodb-kubernetes-operator:0.6.1
+        imagePullPolicy: Always
+        name: mongodb-kubernetes-operator
+      serviceAccountName: mongodb-kubernetes-operator

--- a/charts/community-operator/templates/role.yaml
+++ b/charts/community-operator/templates/role.yaml
@@ -1,0 +1,82 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: mongodb-kubernetes-operator 
+  namespace: {{ .Release.Namespace }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - services
+  - services/finalizers
+  - endpoints
+  - persistentvolumeclaims
+  - events
+  - configmaps
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - daemonsets
+  - replicasets
+  - statefulsets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  verbs:
+  - get
+  - create
+- apiGroups:
+  - apps
+  resourceNames:
+  - mongodb-kubernetes-operator
+  resources:
+  - deployments/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  - deployments
+  verbs:
+  - get
+- apiGroups:
+  - mongodbcommunity.mongodb.com
+  resources:
+  - mongodbcommunity
+  - mongodbcommunity/status
+  - mongodbcommunity/spec
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/charts/community-operator/templates/role_binding.yaml
+++ b/charts/community-operator/templates/role_binding.yaml
@@ -1,0 +1,13 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: mongodb-kubernetes-operator 
+  namespace: {{ .Release.Namespace }}
+subjects:
+- kind: ServiceAccount
+  name: mongodb-kubernetes-operator 
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: mongodb-kubernetes-operator 
+  apiGroup: rbac.authorization.k8s.io

--- a/charts/community-operator/templates/service_account.yaml
+++ b/charts/community-operator/templates/service_account.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: mongodb-kubernetes-operator 
+  namespace: {{ .Release.Namespace }}

--- a/charts/community-operator/values.yaml
+++ b/charts/community-operator/values.yaml
@@ -1,0 +1,82 @@
+# Default values for community-operator.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: nginx
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+service:
+  type: ClusterIP
+  port: 80
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: chart-example.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/charts/ent-operator-database/templates/database-cm.yaml
+++ b/charts/ent-operator-database/templates/database-cm.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Values.name }}-configmap
+  name: {{ .Release.Name }}-configmap
   namespace: {{ .Release.Namespace }}
   annotations:
     "meta.helm.sh/release-name": {{ .Release.Name }}
@@ -13,7 +13,7 @@ metadata:
     "app.kubernetes.io/managed-by": {{ .Release.Service }}
 
 data:
-  projectName: {{ .Values.name }}
+  projectName: {{ .Release.Name }}
   baseUrl: {{ .Values.opsManager.URL }}
 
   # Optional parameters

--- a/charts/ent-operator-database/templates/database-secret.yaml
+++ b/charts/ent-operator-database/templates/database-secret.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Values.name }}-credential
+  name: {{ .Release.Name }}-credential
   namespace: {{ .Release.Namespace }}
   annotations:
     "meta.helm.sh/release-name": {{ .Release.Name }}

--- a/charts/ent-operator-database/templates/database-shard.yaml
+++ b/charts/ent-operator-database/templates/database-shard.yaml
@@ -3,7 +3,7 @@
 apiVersion: mongodb.com/v1
 kind: MongoDB
 metadata:
-  name: {{ .Values.name }}
+  name: {{ .Release.Name }}
   namespace: {{ .Release.Namespace }}
   annotations:
     "meta.helm.sh/release-name": {{ .Release.Name }}
@@ -36,12 +36,12 @@ spec:
 {{- if .Values.opsManager.configMap }}      
       name: {{ .Values.opsManager.configMap }}
 {{- else }}
-      name: {{ .Values.name }}-configmap
+      name: {{ .Release.Name }}-configmap
 {{- end }}
 {{- if .Values.opsManager.secretRef }}
   credentials: {{ .Values.opsManager.secretRef }}
 {{- else }}
-  credentials: {{ .Values.name }}-credential
+  credentials: {{ .Release.Name }}-credential
 {{- end }}
 
   security:

--- a/charts/ent-operator-database/templates/database.yaml
+++ b/charts/ent-operator-database/templates/database.yaml
@@ -3,7 +3,7 @@
 apiVersion: mongodb.com/v1
 kind: MongoDB
 metadata:
-  name: {{ .Values.name }}
+  name: {{ .Release.Name }}
   namespace: {{ .Release.Namespace }}
   annotations:
     "meta.helm.sh/release-name": {{ .Release.Name }}
@@ -28,12 +28,12 @@ spec:
 {{- if .Values.opsManager.configMap }}      
       name: {{ .Values.opsManager.configMap }}
 {{- else }}
-      name: {{ .Values.name }}-configmap
+      name: {{ .Release.Name }}-configmap
 {{- end }}
 {{- if .Values.opsManager.secretRef }}
   credentials: {{ .Values.opsManager.secretRef }}
 {{- else }}
-  credentials: {{ .Values.name }}-credential
+  credentials: {{ .Release.Name }}-credential
 {{- end }}
 
   security:
@@ -77,14 +77,6 @@ spec:
     podTemplate:
       spec:
         terminationGracePeriodSeconds: 10
-        topologySpreadConstraints:
-        - maxSkew: 1
-          topologyKey: zone
-          whenUnsatisfiable: DoNotSchedule
-          labelSelector:
-          matchLabels:
-            foo: bar
-          # This container will be added to each pod as a sidecar
         containers:
           - name: mongodb-enterprise-database
             resources:

--- a/charts/ent-operator-database/templates/mongodb-user-password.yaml
+++ b/charts/ent-operator-database/templates/mongodb-user-password.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ $.Values.name }}-{{ .username }}-secret
+  name: {{ $.Release.Name }}-{{ .username }}-secret
   namespace: {{ $.Release.Namespace }}
   labels:
     "helm.sh/chart": {{ $.Chart.Name }}-{{ $.Chart.Version | replace "+" "_" }}

--- a/charts/ent-operator-database/templates/mongodb-user.yaml
+++ b/charts/ent-operator-database/templates/mongodb-user.yaml
@@ -3,7 +3,7 @@
 apiVersion: mongodb.com/v1
 kind: MongoDBUser
 metadata:
-  name: {{ $.Values.name }}-{{ .username }}-mongodbuser
+  name: {{ $.Release.Name }}-{{ .username }}-mongodbuser
   namespace: {{ $.Release.Namespace }}
   annotations:
     "meta.helm.sh/release-name": {{ $.Release.Name }}
@@ -13,12 +13,12 @@ metadata:
     "app.kubernetes.io/managed-by": {{ $.Release.Service }}
 spec:
   passwordSecretKeyRef:
-    name: {{ $.Values.name }}-{{ .username }}-secret # the name of the secret that stores this user's password
+    name: {{ $.Release.Name }}-{{ .username }}-secret # the name of the secret that stores this user's password
     key: password # the key in the secret that stores the password
   username: {{ .username }}
   db: {{ .db }}
   mongodbResourceRef:
-    name: {{ $.Values.name }} # The name of the MongoDB resource this user will be added to
+    name: {{ $.Release.Name }} # The name of the MongoDB resource this user will be added to
   roles:
     {{- toYaml .roles | nindent 6 }}
 {{- end }}

--- a/charts/ent-operator-database/values.yaml
+++ b/charts/ent-operator-database/values.yaml
@@ -26,13 +26,13 @@ replicaSet:
 opsManager:
   # Ops Manager connection could be configured  with Values and This HELM chart will create
   # nesessary Secret and Config Map.
-  URL:
-  orgid:
-  APIKey:
-  APISecret:
+  URL: ""
+  orgid: ""
+  APIKey: ""
+  APISecret: ""
   # Alternatevly an existing secret and config map could be provided directly
-  configMap: 
-  secretRef: 
+  configMap:
+  secretRef:
 
 security:
   authentication:

--- a/charts/ent-operator-database/values.yaml
+++ b/charts/ent-operator-database/values.yaml
@@ -31,8 +31,8 @@ opsManager:
   APIKey:
   APISecret:
   # Alternatevly an existing secret and config map could be provided directly
-  configMap: opsmanager-configmap
-  secretRef: opsmanager-org-access-key
+  configMap: 
+  secretRef: 
 
 security:
   authentication:
@@ -44,8 +44,8 @@ security:
 
 resources:
   limits:
-    cpu: 2
-    memory: 1.5G
+    cpu: 1
+    memory: 1G
   requests:
     cpu: 1
     memory: 1G
@@ -58,7 +58,7 @@ agent:
 
 persistence:
   single:
-    storage: 10Gi
+    storage: 1Gi
 #   storageClass: standard
 # multiple:
 #   data:
@@ -110,4 +110,4 @@ users:
     password: "%SomeLong%password$"
     roles:
       - db: admin
-        name: readWrite
+        name: readWriteAnyDatabase

--- a/charts/ent-operator-opsmanager/Chart.yaml
+++ b/charts/ent-operator-opsmanager/Chart.yaml
@@ -4,12 +4,17 @@ description: MongoDB Kubernetes Enterprise Operator - Ops Manager Chart
 version: 0.2.5
 kubeVersion: '>=1.15-0'
 keywords:
-- opsManager
-- mongodb
-- database
-- nosql
+  - opsManager
+  - mongodb
+  - database
+  - nosql
 home: https://github.com/mongodb/mongodb-enterprise-kubernetes
 icon: https://camo.githubusercontent.com/d473c25e361fb2206f06bdcf24028e8d52bc30d1/68747470733a2f2f6d6f6e676f64622d6b756265726e657465732d6f70657261746f722e73332e616d617a6f6e6177732e636f6d2f696d672f4c6561662d466f7265737425343032782e706e67
 maintainers:
-- name: theburi
-  email: belika@hotmail.com
+  - name: theburi
+    email: belika@hotmail.com
+dependencies:
+  - name: mongodb-enterprise-operator
+    version: "0.3.0"
+    repository: "https://mongodb.github.io/helm-charts"
+    condition: mongodb-enterprise-operator.enabled

--- a/charts/ent-operator-opsmanager/Chart.yaml
+++ b/charts/ent-operator-opsmanager/Chart.yaml
@@ -13,8 +13,3 @@ icon: https://camo.githubusercontent.com/d473c25e361fb2206f06bdcf24028e8d52bc30d
 maintainers:
 - name: theburi
   email: belika@hotmail.com
-dependencies:
-  - name: mongodb-enterprise-operator
-    version: "0.3.0"
-    repository: "https://mongodb.github.io/helm-charts"
-    condition: mongodb-enterprise-operator.enabled

--- a/charts/ent-operator/Chart.yaml
+++ b/charts/ent-operator/Chart.yaml
@@ -8,6 +8,7 @@ keywords:
 - database
 - nosql
 home: https://github.com/mongodb/helm-charts
+icon: https://camo.githubusercontent.com/d473c25e361fb2206f06bdcf24028e8d52bc30d1/68747470733a2f2f6d6f6e676f64622d6b756265726e657465732d6f70657261746f722e73332e616d617a6f6e6177732e636f6d2f696d672f4c6561662d466f7265737425343032782e706e67
 maintainers:
 - name: theburi
   email: belika@hotmail.com

--- a/charts/fastapi-sample-app/.helmignore
+++ b/charts/fastapi-sample-app/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/fastapi-sample-app/Chart.yaml
+++ b/charts/fastapi-sample-app/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: fastapi-sample-app
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.16.0"

--- a/charts/fastapi-sample-app/Chart.yaml
+++ b/charts/fastapi-sample-app/Chart.yaml
@@ -21,4 +21,8 @@ version: 0.1.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.16.0"
+appVersion: "1.0.0"
+maintainers:
+  - name: MongoDB
+    email: support@mongodb.com
+home: https://github.com/mongodb/mongodb-atlas-kubernetes

--- a/charts/fastapi-sample-app/Chart.yaml
+++ b/charts/fastapi-sample-app/Chart.yaml
@@ -1,28 +1,11 @@
 apiVersion: v2
 name: fastapi-sample-app
 description: A Helm chart for Kubernetes
-
-# A chart can be either an 'application' or a 'library' chart.
-#
-# Application charts are a collection of templates that can be packaged into versioned archives
-# to be deployed.
-#
-# Library charts provide useful utilities or functions for the chart developer. They're included as
-# a dependency of application charts to inject those utilities and functions into the rendering
-# pipeline. Library charts do not define any templates and therefore cannot be deployed.
 type: application
-
-# This is the chart version. This version number should be incremented each time you make changes
-# to the chart and its templates, including the app version.
-# Versions are expected to follow Semantic Versioning (https://semver.org/)
 version: 0.1.0
-
-# This is the version number of the application being deployed. This version number should be
-# incremented each time you make changes to the application. Versions are not expected to
-# follow Semantic Versioning. They should reflect the version the application is using.
-# It is recommended to use it with quotes.
 appVersion: "1.0.0"
 maintainers:
   - name: MongoDB
     email: support@mongodb.com
+icon: https://camo.githubusercontent.com/d473c25e361fb2206f06bdcf24028e8d52bc30d1/68747470733a2f2f6d6f6e676f64622d6b756265726e657465732d6f70657261746f722e73332e616d617a6f6e6177732e636f6d2f696d672f4c6561662d466f7265737425343032782e706e67
 home: https://github.com/mongodb/mongodb-atlas-kubernetes

--- a/charts/fastapi-sample-app/templates/deployment.yaml
+++ b/charts/fastapi-sample-app/templates/deployment.yaml
@@ -1,0 +1,39 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}
+  replicas: 1 # tells deployment to run 2 pods matching the template
+  template:
+    metadata:
+      labels:
+        app: {{ .Release.Name }}
+    spec:
+      containers:
+      - name: mongodb-atlas-fastapi
+        image: public.ecr.aws/u1r4t8v5/mongodb-atlas-fastapi
+        ports:
+          - containerPort: 8080
+        env:
+{{- if .Values.enterprise }}
+          - name: "MONGODB_USERNAME"
+            value: {{ .Values.enterprise.username }}
+          - name: "MONGODB_PASSWORD"
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.enterprise.db }}-{{ .Values.enterprise.username }}-secret
+                key: password
+          - name: "MONGODB_URI_SRV"
+            value: "mongodb+srv://{{ .Values.enterprise.db }}-svc.{{ .Values.enterprise.namespace }}.svc.cluster.local/test?ssl=false&authSource=admin"
+{{- else }}
+          - name: "MONGODB_URI_SRV"
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.connectionSecret }}
+                key: connectionString.standardSrv
+{{- end }}
+

--- a/charts/fastapi-sample-app/templates/service.yaml
+++ b/charts/fastapi-sample-app/templates/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service 
+metadata:
+  name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  selector:
+    app: {{ .Release.Name }}
+  ports:
+    - port: {{ .Values.externalLoadBalancerPort }}
+      targetPort: 8080
+  type: LoadBalancer
+

--- a/charts/fastapi-sample-app/values-enterprise.yaml
+++ b/charts/fastapi-sample-app/values-enterprise.yaml
@@ -1,0 +1,6 @@
+externalLoadBalancerPort: 80
+enterprise:
+    username: app-user
+    db: some-db
+    namespace: mongodb
+

--- a/charts/fastapi-sample-app/values.yaml
+++ b/charts/fastapi-sample-app/values.yaml
@@ -4,6 +4,5 @@ env:
   - name: "MONGODB_URI_SRV"
     valueFrom:
       secretKeyRef:
-        name: "some-secret" 
+        name: "some-secret"
         key: connectionString.standardSrv
-

--- a/charts/fastapi-sample-app/values.yaml
+++ b/charts/fastapi-sample-app/values.yaml
@@ -1,0 +1,9 @@
+externalLoadBalancerPort: 80
+connectionSecret: ""
+env:
+  - name: "MONGODB_URI_SRV"
+    valueFrom:
+      secretKeyRef:
+        name: "some-secret" 
+        key: connectionString.standardSrv
+

--- a/helpers/atlas-mongodb-user-connection-secret.sh
+++ b/helpers/atlas-mongodb-user-connection-secret.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+PROJECT_NAME="${1}"
+echo "PROJECT_NAME=${PROJECT_NAME}"
+PROJECT_ID=$(mongocli iam project list --output=json | jq --arg name "${PROJECT_NAME}" -r '.results[] | select(.name==$name) | .id')
+CLUSTER_NAME="${2:-none}"
+if [[ "${CLUSTER_NAME}" == "none" ]]; then
+    CLUSTER_INFO=$(mongocli atlas clusters list --projectId ${PROJECT_ID} --output=json | jq '.[0]')
+else
+    CLUSTER_INFO=$(mongocli atlas clusters list --projectsId ${PROJECT_ID} --output=json | jq --arg name "${CLUSTER_NAME}" -r '.[] | select(.name==$name) | .')
+fi
+echo "CLUSTER_INFO=${CLUSTER_INFO}"
+
+
+echo "\
+apiVersion: v1
+kind: Secret
+metadata:
+  name: green-db-admin-admin
+  namespace: community
+type: Opaque
+data:
+  connectionString.standard: ${CLUSTER_INFO}
+  connectionString.standardSrv: bW9uZ29kYitzcnY6Ly9hZG1pbjp0ZXN0aW5nMTIzNCUyMUBncmVlbi1kYi1zdmMuY29tbXVuaXR5LnN2Yy5jbHVzdGVyLmxvY2FsL2FkbWluP3NzbD1mYWxzZQ==
+  password: dGVzdGluZzEyMzQh
+  username: YWRtaW4=
+"

--- a/helpers/quickstart-atlas-cluster.sh
+++ b/helpers/quickstart-atlas-cluster.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+cluster_name=${1}
+ATLAS_PUBLIC_KEY=XXXX
+ATLAS_PRIVATE_KEY=YYYY
+ATLAS_ORG_ID=ZZZZ
+helm install $cluster_name \
+    ./charts/atlas-cluster \
+    --set atlas.publicApiKey=${ATLAS_PUBLIC_KEY} \
+    --set atlas.privateApiKey=${ATLAS_PRIVATE_KEY} \
+    --set atlas.orgId=${ATLAS_ORG_ID} \
+    --set project.name=${cluster_name} \
+    --set project.atlasProjectName=${cluster_name} \
+

--- a/helpers/quickstart-atlas-operator.sh
+++ b/helpers/quickstart-atlas-operator.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+helm install atlas-operator ./charts/atlas-operator
+


### PR DESCRIPTION
In this PR:
- added possibility to create multiple clusters
solves: #47 

- use existing k8s secrets, instead of creating one
- add annotations to `AtlasCluster` and `AtlasProject` CR to be able to use annotation added in this PR - https://github.com/mongodb/mongodb-atlas-kubernetes/pull/213
- make project creation optional, as well as all project-level resources (database users), so the chart can be used for clusters creation only and reference to existing atlas project