### PR TITLE
[atlas-operator] Align helm chart to the release 0.6.0

### DIFF
--- a/charts/atlas-operator/Chart.yaml
+++ b/charts/atlas-operator/Chart.yaml
@@ -3,7 +3,7 @@ name: mongodb-atlas-operator
 description: |-
   MongoDB Atlas Operator - a Helm chart for installing and upgrading Atlas Operator: the official Kubernetes operator allowing to manage MongoDB Atlas resources from Kubernetes
 type: application
-version: 0.2.3
+version: 0.2.4
 appVersion: 0.6.1
 kubeVersion: ">=1.15.0-0"
 keywords:

--- a/charts/atlas-operator/templates/_helpers.tpl
+++ b/charts/atlas-operator/templates/_helpers.tpl
@@ -68,6 +68,13 @@ RBAC permissions
 - apiGroups:
   - ""
   resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
   - secrets
   verbs:
   - create


### PR DESCRIPTION
in [Release 0.6.0](https://github.com/mongodb/mongodb-atlas-kubernetes/pull/293) were adjusted [rbac role rules](https://github.com/mongodb/mongodb-atlas-kubernetes/pull/293/files#diff-a0d60ebeabd98cd67e354f0ad577f642a0133288729645659c57b4ec8ded8d82R934-R940)

with the current helm version I'm getting:
```
'events is forbidden: User "system:serviceaccount:mongodb:atlas-operator" cannot create resource "events" in API group "" in the namespace "namespace"' (will not retry!)
```

This PR is to fix the error above