### PR TITLE
CLOUDP-101436: Reworked docs for Atlas helm chart.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,29 @@
+# MongoDB Helm Charts repository for Kubernetes
 
-## MongoDB Helm Charts repository for Kubernetes
+## Trial Version of Helm Charts
 
-## Charts
+This repository contains Helm Charts for different MongoDB products.
 
-This repository contains sample HELM charts for different MongoDB products
+| Charts                                            | Description                                                 |
+| ------------------------------------------------- | ----------------------------------------------------------- |
+| [atlas-operator](charts/atlas-operator)           | MongoDB Atlas Operator Helm Chart                           |
+| [atlas-operator-crds](charts/atlas-operator-crds) | MongoDB Atlas Custom Resource Definitions (CRDs) Helm Chart |
+| [atlas-cluster](charts/atlas-cluster)             | MongoDB Atlas Cluster Helm Chart                            |
 
-| Charts                  | Description                                        |
-|-------------------------|----------------------------------------------------|
-| atlas-operator          | MongoDB Atlas Helm Chart. Install Operator Chart   |
-| atlas-operator-crds     | MongoDB Atlas Collection of CRD's                  |
-|-------------------------|----------------------------------------------------|
-| ent-operator            | MongoDB Enterprise Kubernetes operator.            |
-| ent-operator-database   | Deploy MongoDB Enterprise DataBase.                |
-| ent-operator-opsmanager | Deploy MongoDB Enterprise OpsManager.              |
+## Adding the MongoDB Helm Repo
 
+The MongoDB Helm repository can be added using the `helm repo add` command, like
+in the following example:
 
+```
+$ helm repo add mongodb https://mongodb.github.io/helm-charts
+"mongodb" has been added to your repositories
+```
 
+## Additional Charts
 
+All of MongoDB Helm charts will be moved into this repository. In the meantime,
+please find them on their own repositories:
 
+- [MongoDB Enterprise Kubernetes Operator](https://github.com/mongodb/mongodb-enterprise-kubernetes)
+- [MongoDB Community Operator](https://github.com/mongodb/mongodb-kubernetes-operator)

--- a/charts/README.md
+++ b/charts/README.md
@@ -1,19 +1,14 @@
-# Quick Start
+# MongoDB Charts Repo
 
-Please note that Database and OpsManager include an operator as a dependency. There is no need to install is separately.
+To use these charts the MongoDB Helm repository needs to be added with:
 
-```helm repo add mongodb https://mongodb.github.io/helm-charts```
-```helm dependency update```
+```shell
+helm repo add mongodb https://mongodb.github.io/helm-charts
+```
 
-In order to install Ops Manager run this command
+There are many Helm charts in this repository, please read each Chart's README
+file for instructions on how to install each particular Helm Chart and its
+capabilities.
 
-```helm upgrade opsmanager . -n opsmanager --create-namespace  -i```
-
-In order to install MongoDB DataBase:
-
-```helm upgrade mongodb . --set opsManager.configMap=opsmanager-configmap --set opsManager.secretRef=opsmanager-org-access-key  -n $MONGODB_NAMESPACE --create-namespace -i```
-
-Where `opsmanager-configmap` and `opsmanager-org-access-key` contain OpsManager connection properties
-
-Helper script could be found at ../helpers/MongoDB-deploy.sh It contains an example that automates MongoDB Deployment using mongocli
-
+Currently, only the [Atlas Operator Helm Chart](./atlas-operator) should be
+installed from this repository and it is considered a _Trial_.

--- a/charts/atlas-operator-crds/README.md
+++ b/charts/atlas-operator-crds/README.md
@@ -1,19 +1,26 @@
 # MongoDB Atlas Operator CRDs Helm Chart
 
-A Helm chart for installing and upgrading Custom Resource Definitions (CRDs) for the [MongoDB Atlas Operator](https://github.com/mongodb/mongodb-atlas-kubernetes). These CRDs are 
-required by the Atlas Operator to work. 
+A Helm chart for installing and upgrading Custom Resource Definitions (CRDs) for
+the [MongoDB Atlas
+Operator](https://github.com/mongodb/mongodb-atlas-kubernetes). These CRDs are
+required by the [Atlas Operator](../atlas-operator/) to work.
+
+This Helm chart can be installed manually, following these instructions. If needed, it can
+also be installed automatically as a dependency by the [Atlas
+Operator](../atlas-operator/).
 
 ## Usage
+
+_If you haven't done it yet, [add the MongoDB Helm repository](../README.md)._
 
 Installing the CRDs into the Kubernetes Cluster:
 
 ```
-helm repo add mongodb https://mongodb.github.io/helm-charts
-helm install mongodb-atlas-operator-crds mongodb/mongodb-atlas-operator-crds
+helm install atlas-operator-crds mongodb/mongodb-atlas-operator-crds
 ```
 
 Upgrading the CRDs:
 
 ```
-helm upgrade mongodb-atlas-operator-crds mongodb/mongodb-atlas-operator-crds
+helm upgrade atlas-operator-crds mongodb/mongodb-atlas-operator-crds
 ```

--- a/charts/atlas-operator/README.md
+++ b/charts/atlas-operator/README.md
@@ -1,37 +1,63 @@
 # MongoDB Atlas Operator Helm Chart
 
-A Helm chart for installing and upgrading [MongoDB Atlas Operator](https://github.com/mongodb/mongodb-atlas-kubernetes). 
-The Operator allows to manage resources from Atlas (projects, clusters, database users, etc) not leaving the Kubernetes cluster.
+A Helm chart for installing and upgrading the [MongoDB Atlas
+Operator](https://github.com/mongodb/mongodb-atlas-kubernetes).
 
 ## Prerequisites
 
-You need to install the [Atlas Operator CRDs](../atlas-operator-crds) first before installing the Operator.
+If required, you can install the Atlas Custom Resource Definitions [Helm
+Chart](../atlas-operator-crds/) separatelly or as a dependency of this Chart.
 
-## Usage
+If the `atlas-operator-crds` Helm chart has been installed already, or if you
+don't want to install the CRDs (because you have already installed them), then
+you need to pass `--set mongodb-atlas-operator-crds.enabled=false`, when
+installing the Operator.
 
-### Installing the Operator (in clusterwide mode) into the Kubernetes Cluster:
+### Watching over all Namespaces
 
+This will install the Operator in _Cluster wide mode_. The Operator will watch
+over all the namespaces in the Kubernetes cluster.
+
+```shell
+helm install atlas-operator mongodb/mongodb-atlas-operator \
+    --namespace=atlas-operator \
+    --create-namespace
 ```
-helm repo add mongodb https://mongodb.github.io/helm-charts
-helm install atlas-operator --namespace=atlas-operator --create-namespace mongodb/mongodb-atlas-operator
+
+### Watching over same Namespace
+
+This installation mode will restrict the Operator to watch over resources created
+in the same namespace the Operator is installed.
+
+```shell
+helm install atlas-operator mongodb/mongodb-atlas-operator \
+    --namespace=atlas-operator \
+    --set watchNamespaces=atlas-operator \
+    --create-namespace
 ```
 
-### Installing the Operator (in namespaced mode - watching the self namespace) into the Kubernetes Cluster:
+### Watching over all Namespaces with Global Atlas configuration
 
-```
-helm repo add mongodb https://mongodb.github.io/helm-charts
-helm install atlas-operator --namespace=operator --set watchNamespaces=operator --create-namespace mongodb/mongodb-atlas-operator
-```
+In this mode the Operator will be installed in _Cluster wide mode_ with [Global
+Atlas configuration](https://docs.atlas.mongodb.com/reference/atlas-operator/configure-ak8so-access-to-atlas/).
 
-### Installing the Operator (in clusterwide mode) and configure the Global API Secret:
-
-```
-helm repo add mongodb https://mongodb.github.io/helm-charts
-helm install atlas-operator --namespace=atlas-operator --create-namespace --set globalConnectionSecret.publicApiKey=<the_public_key> --set globalConnectionSecret.privateApiKey=<the_private_key> --set globalConnectionSecret.orgId=<the_org_id> mongodb/mongodb-atlas-operator
+```shell
+helm install atlas-operator mongodb/mongodb-atlas-operator \
+    --namespace=atlas-operator \
+    --create-namespace \
+    --set globalConnectionSecret.publicApiKey=<the_public_key> \
+    --set globalConnectionSecret.privateApiKey=<the_private_key> \
+    --set globalConnectionSecret.orgId=<the_org_id>
 ```
 
 ### Upgrading the Operator:
 
 ```
-helm upgrade mongodb-atlas-operator mongodb/mongodb-atlas-operator
+helm upgrade atlas-operator mongodb/mongodb-atlas-operator
 ```
+
+## Creating Atlas Resources
+
+After the `atlas-operator` Helm Chart has been installed, you can proceed to
+[Atlas Cluster](../atlas-cluster) Helm Chart to create your first Atlas
+database.

--- a/charts/atlas-operator/values.yaml
+++ b/charts/atlas-operator/values.yaml
@@ -1,4 +1,6 @@
 mongodb-atlas-operator-crds:
+  # Make this disabled if you don't want to install
+  # the CRD dependency automatically.
   enabled: true
 
 # atlasURI is the URI of the MongoDB Atlas


### PR DESCRIPTION
## Summary

I've reworked the docs for the Atlas operator, and the top-level README and charts/README.

- Make it clear which Helm charts can be installed from the `mongodb` repo. Also stating the _Trial_ state of Atlas operator.
- Removed outdated docs
- Clearly stated the relation between `atlas-operator` and `atlas-operator-crds` charts, and how to install `atlas-operator` without `crds` dependency.
- Improved narrative in almost all the documentation pages.