### PR TITLE
Set configurable operator resources

### DIFF
--- a/charts/community-operator/templates/mongodbcommunity_cr_with_tls.yaml
+++ b/charts/community-operator/templates/mongodbcommunity_cr_with_tls.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.createResource }}
 {{- if and .Values.resource.tls.enabled .Values.resource.tls.useCertManager }}
 # cert-manager resources
 apiVersion: cert-manager.io/v1
@@ -53,7 +54,6 @@ spec:
 {{- end }}
 
 # mongodb resources
-{{- if .Values.createResource }}
 ---
 apiVersion: mongodbcommunity.mongodb.com/v1
 kind: MongoDBCommunity

--- a/charts/community-operator/templates/operator.yaml
+++ b/charts/community-operator/templates/operator.yaml
@@ -66,12 +66,7 @@ spec:
           imagePullPolicy: {{ .Values.registry.pullPolicy}}
           name: {{ .Values.operator.deploymentName }}
           resources:
-            limits:
-              cpu: 1100m
-              memory: 1Gi
-            requests:
-              cpu: 500m
-              memory: 200Mi
+            {{- toYaml .Values.operator.resources | nindent 12 }}
           securityContext:
             readOnlyRootFilesystem: true
             runAsUser: 2000

--- a/charts/community-operator/values.yaml
+++ b/charts/community-operator/values.yaml
@@ -17,6 +17,15 @@ operator:
   # Version of mongodb-kubernetes-operator
   version: 0.7.0
 
+  # Resources allocated to Operator Pod
+  resources:
+    limits:
+      cpu: 1100m
+      memory: 1Gi
+    requests:
+      cpu: 500m
+      memory: 200Mi
+
 ## Operator's database
 database:
   name: mongodb-database

--- a/charts/community-operator/values.yaml
+++ b/charts/community-operator/values.yaml
@@ -17,6 +17,9 @@ operator:
   # Version of mongodb-kubernetes-operator
   version: 0.7.0
 
+  # Uncomment this line to watch all namespaces
+  # watchNamespace: "*"
+
   # Resources allocated to Operator Pod
   resources:
     limits:


### PR DESCRIPTION
This patch brings 2 changes that were awaiting approval/merge to the previous location of the Helm chart. The old PRs are:

* https://github.com/mongodb/mongodb-kubernetes-operator/pull/743
* https://github.com/mongodb/mongodb-kubernetes-operator/pull/704
