### PR TITLE
[community-operator]: add support for extra environment variables

### DIFF
--- a/charts/community-operator/templates/operator.yaml
+++ b/charts/community-operator/templates/operator.yaml
@@ -38,6 +38,9 @@ spec:
         - command:
             - /usr/local/bin/entrypoint
           env:
+{{- if .Values.operator.extraEnvs }}
+            {{ toYaml .Values.operator.extraEnvs | nindent 12 }}
+{{- end }}
             - name: WATCH_NAMESPACE
 {{- if .Values.operator.watchNamespace}}
               value: "{{ .Values.operator.watchNamespace }}"

--- a/charts/community-operator/values.yaml
+++ b/charts/community-operator/values.yaml
@@ -29,6 +29,12 @@ operator:
       cpu: 500m
       memory: 200Mi
 
+  # Additional environment variables
+  extraEnvs: []
+  #environment:
+  #  - name: CLUSTER_DOMAIN
+  #    value: my-cluster.domain
+
 ## Operator's database
 database:
   name: mongodb-database

--- a/charts/community-operator/values.yaml
+++ b/charts/community-operator/values.yaml
@@ -31,9 +31,9 @@ operator:
 
   # Additional environment variables
   extraEnvs: []
-  #environment:
-  #  - name: CLUSTER_DOMAIN
-  #    value: my-cluster.domain
+  # environment:
+  # - name: CLUSTER_DOMAIN
+  #   value: my-cluster.domain
 
 ## Operator's database
 database:


### PR DESCRIPTION
Add support for extra environment variables when deploying the operator (`operator.extraEnvs`). This is needed in order to configure the operator with custom `CLUSTER_DOMAIN` (mongodb/mongodb-kubernetes-operator#747)