### PR TITLE
Installs cert-manager independently

### DIFF
--- a/charts/community-operator/templates/mongodbcommunity_cr_with_tls.yaml
+++ b/charts/community-operator/templates/mongodbcommunity_cr_with_tls.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.createResource .Values.resource.tls.enabled .Values.resource.tls.useCertManager }}
+{{- if and .Values.resource.tls.enabled .Values.resource.tls.useCertManager }}
 # cert-manager resources
 apiVersion: cert-manager.io/v1
 kind: Issuer
@@ -50,7 +50,9 @@ spec:
   commonName: "*.{{ .Values.resource.name }}-svc.{{ .Values.namespace }}.svc.cluster.local"
   dnsNames:
     - "*.{{ .Values.resource.name }}-svc.{{ .Values.namespace }}.svc.cluster.local"
+{{- end }}
 
+{{- if .Values.createResource }}
 # mongodb resources
 ---
 apiVersion: mongodbcommunity.mongodb.com/v1

--- a/charts/community-operator/values.yaml
+++ b/charts/community-operator/values.yaml
@@ -53,6 +53,13 @@ registry:
   operator: quay.io/mongodb
   pullPolicy: Always
 
+# Set to false if CRDs have been installed already. The CRDs can be installed
+# manually from the code repo: github.com/mongodb/mongodb-kubernetes-operator or
+# using the `community-operator-crds` Helm chart.
+community-operator-crds:
+  enabled: true
+
+# Deploys MongoDB with `resource` attributes.
 createResource: false
 resource:
   name: mongodb-replica-set
@@ -60,6 +67,8 @@ resource:
   members: 3
   tls:
     enabled: true
+
+    # Installs Cert-Manager in this cluster.
     useCertManager: true
     certificateKeySecretRef: tls-certificate
     caCertificateSecretRef: tls-ca-key-pair


### PR DESCRIPTION
# Summary

Cert-Manager and Database resource are installed independently of each other. I put them in 2 different if blocks.

This is required for the Community E2E tests that need cert-manager to be installed but not the Database resource. See: https://github.com/mongodb/mongodb-kubernetes-operator/blob/48ae26a1e96266cf337a4fe3ac1093cc209cb2d2/test/e2e/setup/setup.go#L146

I also added an option to not install the dependant CRDs Chart. (`community-operator-crds.enabled`)