### PR TITLE
CLOUDP-101993: Documents Community Chart.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,18 +2,20 @@
 
 ## Trial Version of Helm Charts
 
-This repository contains Helm Charts for different MongoDB products. Currently,
-only the MongoDB Atlas Operator is supported (in _Trial mode_).
+This repository contains Helm Charts for different MongoDB products.
 
 | Charts                                            | Description                                                               |
 | ------------------------------------------------- | ------------------------------------------------------------------------- |
 | [atlas-operator](charts/atlas-operator)           | MongoDB Atlas Operator Helm Chart. [_Start Here!_](charts/atlas-operator) |
 | [atlas-cluster](charts/atlas-cluster)             | MongoDB Atlas Cluster Helm Chart. Create Mongo Database resources.        |
 | [atlas-operator-crds](charts/atlas-operator-crds) | MongoDB Atlas Custom Resource Definitions (CRDs) Helm Chart.              |
+| [community-operator](charts/community-operator)   | MongoDB Community Operator Helm Chart.                                    |
+| [community-operator-crds](charts/community-operator-crds) | MongoDB Community Custom Resource Definitions (CRDs) Helm Chart.  |
 
-- Please note that the [atlas-operator-crds](charts/atlas-operator-crds) Helm
-  chart, will be installed, by default, as a dependency by the
-  [atlas-operator](charts/atlas-operator).
+- Please note that the `CRD` Charts ([Community](charts/community-operator-crds)
+  and [Atlas](charts/atlas-operator-crds)) will be installed, by default,
+  as a dependency by the corresponding [Community](charts/community-operator)
+  and [Atlas](charts/atlas-operator) Charts.
 
 ## Adding the MongoDB Helm Repo
 
@@ -31,4 +33,3 @@ All of MongoDB Helm charts will be moved into this repository. In the meantime,
 please find them on their own repositories:
 
 - [MongoDB Enterprise Kubernetes Operator](https://github.com/mongodb/mongodb-enterprise-kubernetes)
-- [MongoDB Community Operator](https://github.com/mongodb/mongodb-kubernetes-operator)

--- a/charts/atlas-operator/README.md
+++ b/charts/atlas-operator/README.md
@@ -6,7 +6,7 @@ Operator](https://github.com/mongodb/mongodb-atlas-kubernetes).
 ## Prerequisites
 
 If required, you can install the Atlas Custom Resource Definitions [Helm
-Chart](../atlas-operator-crds/) separatelly or as a dependency of this Chart.
+Chart](../atlas-operator-crds/) separately or as a dependency of this Chart.
 
 If the `atlas-operator-crds` Helm chart has been installed already, or if you
 don't want to install the CRDs (because you have already installed them), then

--- a/charts/community-operator/README.md
+++ b/charts/community-operator/README.md
@@ -1,0 +1,83 @@
+# MongoDB Community Kubernetes Operator Helm Chart
+
+A Helm Chart for installing and upgrading the [MongoDB Community
+Kubernetes Operator](https://github.com/mongodb/mongodb-kubernetes-operator).
+
+## Prerequisites
+
+If required, you can install the Custom Resource Definitions [Helm
+Chart](../community-operator-crds/) separately or as a dependency of this Chart.
+
+If the `community-operator-crds` Helm chart has been installed already, or if you
+don't want to install the CRDs (because you have already installed them), then
+you need to pass `--set community-operator-crds.enabled=false`, when
+installing the Operator.
+
+## Installing Community Operator
+
+You can install the MongoDB Community Operator easily with:
+
+``` shell
+helm install community-operator mongodb/community-operator
+```
+
+This will install `CRD`s and Community Operator in the current namespace
+(`default` by _default_). You can pass a different namespace with:
+
+``` shell
+helm install community-operator mongodb/community-operator --namespace mongodb [--create-namespace]
+```
+
+To install the Community Operator in a namespace called `mongodb` with the
+optional `--create-namespace` in case `mongodb` didn't exist yet.
+
+
+## Deploying a MongoDB Replica Set
+
+The Community Operator will be watching for resources of type
+`mongodbcommunity.mongodbcommunity.mongodb.com`; you can quickly install
+a sample Mongo Database with:
+
+``` shell
+kubectl apply -f https://raw.githubusercontent.com/mongodb/mongodb-kubernetes-operator/master/config/samples/mongodb.com_v1_mongodbcommunity_cr.yaml [--namespace mongodb]
+```
+
+- _Note: Make sure you add the `--namespace` option when needed._
+- _Note 2: A new user will be created with a generic password. Make sure this is
+  only used for testing purposes._
+
+After a few minutes you will have a 3-member MongoDB Replica Set installed in
+your cluster, that you can check with:
+
+``` shell
+$ kubectl get mdbc
+NAME              PHASE     VERSION
+example-mongodb   Running   4.2.6
+```
+
+## Connecting to MongoDB from a Client Application
+
+The Operator will create a `Secret` object, _per user_, created as part of the
+deployment of the MongoDB resource. Each `Secret` will contain a _Connection
+String_ that can be mounted into a client application to connect to this MongoDB
+instance.
+
+The name of this `Secret` object follows the convention:
+
+- `<mongodb-resource-name>-<database>-<username>`.
+
+In our example, the above `kubectl apply` command will create a MongoDB resource
+with name `example-mongodb`, with a user `my-user` on the Database `admin`. The
+resulting `Secret` will be named:
+
+- `example-mongodb-admin-my-user`
+
+This `Secret` object will contain the following attributes:
+
+- `connectionString.standard`
+- `connectionString.standardSrv`
+- `username`
+- `password`
+
+A client application will be able to connect using the `connectionString`
+attributes or the `username` and `password` ones.

--- a/charts/community-operator/README.md
+++ b/charts/community-operator/README.md
@@ -62,9 +62,14 @@ deployment of the MongoDB resource. Each `Secret` will contain a _Connection
 String_ that can be mounted into a client application to connect to this MongoDB
 instance.
 
-The name of this `Secret` object follows the convention:
+The name of this `Secret` object follows the convention[^1]:
 
 - `<mongodb-resource-name>-<database>-<username>`.
+
+[^1]: Please note that the MongoDB `username` should comply with
+    [DNS-1123](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names)
+    for the Operator to be able to create this Secret. This is a known issue
+    with the Community Operator.
 
 In our example, the above `kubectl apply` command will create a MongoDB resource
 with name `example-mongodb`, with a user `my-user` on the Database `admin`. The


### PR DESCRIPTION
# Summary

This patch does 2 things:

- Documents the installation and use of the Community Chart

# Update

I won't do the following task with this change, because multiple test are broken and can't figure out what's wrong for now. Will do as a follow-up instead.

- Changes the chart so it can be installed on a namespace using `--namespace <ns>` and `--create-namespace` instead of `--set namespace=namespace`.