### PR TITLE
Increases community-operator-crds version.

### DIFF
--- a/charts/community-operator-crds/Chart.yaml
+++ b/charts/community-operator-crds/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: community-operator-crds
 description: MongoDB Kubernetes Community Operator - CRDs
 type: application
-version: 0.7.1
-appVersion: 0.7.1
+version: 0.7.2
+appVersion: 0.7.2
 kubeVersion: ">=1.16-0"
 keywords:
   - mongodb


### PR DESCRIPTION
Increases version to 0.7.2.  This is required before releasing `community-operator` chart to same version.