### PR TITLE
supporting random creds for the Atlas operator

### DIFF
--- a/charts/atlas-cluster/README.md
+++ b/charts/atlas-cluster/README.md
@@ -49,6 +49,11 @@ helm install atlas-cluster mongodb/atlas-cluster\
     --set atlas.publicApiKey='<publicKey>' \
     --set atlas.privateApiKey='<privateApiKey>'
 ```
+Note, by default a random password will be generated. You can optionally also pass in a random username, however since this value is shared across templates this must be passed in, for example:
+
+```shell
+helm template --set "users[0].username=$(mktemp | cut -f2 -d.)" my-cluster mongodb/atlas-cluster 
+```
 
 ## Connecting to MongoDB Atlas Cluster
 

--- a/charts/atlas-cluster/templates/atlas-mongodb-user-secret.yaml
+++ b/charts/atlas-cluster/templates/atlas-mongodb-user-secret.yaml
@@ -10,6 +10,6 @@ metadata:
     {{- include "atlas-cluster.labels" $ | nindent 4 }}
 type: Opaque
 stringData:
-  password: {{ .password | quote }}
+  password: {{ .password | default (randAlphaNum 32 | b64enc)| quote }}
 {{- end }}
 {{- end }}

--- a/charts/atlas-cluster/values.yaml
+++ b/charts/atlas-cluster/values.yaml
@@ -60,7 +60,7 @@ clusters:
 users:
   - username: admin-user
     databaseName: admin
-    password: 
+    password:
     roles:
       - databaseName: admin
         roleName: atlasAdmin

--- a/charts/atlas-cluster/values.yaml
+++ b/charts/atlas-cluster/values.yaml
@@ -60,7 +60,7 @@ clusters:
 users:
   - username: admin-user
     databaseName: admin
-    password: "%SomeLong%password$foradmin"
+    password: 
     roles:
       - databaseName: admin
         roleName: atlasAdmin


### PR DESCRIPTION
This adds support for generating a random password for the Atlas DB User CR. There is also docs on how to inject a random username into the chart.
﻿
