### PR TITLE
Make atlas-cluster's default values safe and suitable for override

### DIFF
--- a/charts/atlas-cluster/README.md
+++ b/charts/atlas-cluster/README.md
@@ -1,12 +1,12 @@
 # MongoDB Atlas Cluster Helm Chart
 
-The MongoDB Atlas Operator provides a native integration between the Kubernetes
+The MongoDB Atlas Operator provides native integration between the Kubernetes
 orchestration platform and MongoDB Atlas — the only multi-cloud document
 database service that gives you the versatility you need to build sophisticated
 and resilient applications that can adapt to changing customer demands and
 market trends.
 
-The Atlas Cluster Helm Chart knows how to manager Atlas resources bound to
+The Atlas Cluster Helm Chart knows how to manage Atlas resources bound to
 Custom Resources in your Kubernetes Cluster. These resources are:
 
 - Atlas Projects: An Atlas Project is a place to create your MongoDB clusters,
@@ -16,7 +16,7 @@ Custom Resources in your Kubernetes Cluster. These resources are:
 - Atlas Database User: An Atlas Database User is a User you can authenticate as
   and login into an Atlas Cluster.
 
-By default the `atlas-cluster` Helm Chart will create a user to connect to the
+By default, the `atlas-cluster` Helm Chart will create a user to connect to the
 newly deployed Atlas Cluster, avoiding having to do this from the Atlas UI.
 
 ## Prerequisites
@@ -38,7 +38,7 @@ needs to be installed already.
 
 3. Deploy MongoDB Atlas Cluster
 
-In the following example you have to set the correct `<orgId>`, `publicKey` and `privateKey`.
+In the following example, you have to set the correct `<orgId>`, `publicKey` and `privateKey`.
 
 ```shell
 helm install atlas-cluster mongodb/atlas-cluster\
@@ -68,7 +68,7 @@ The current state of your new Atlas cluster can be found in the
 kubectl get atlasdatabaseusers atlas-cluster-admin-user -o=jsonpath='{.status.conditions[?(@.type=="Ready")].status}'
 ```
 
-Default HELM Chart values will create single Atlas Admin user with name
+Default HELM Chart values will create a single Atlas Admin user with the name
 `atlas-cluster-admin-user`. Check the status of `AtlasDatabaseUser` resource for
 Ready state.
 

--- a/charts/atlas-cluster/README.md
+++ b/charts/atlas-cluster/README.md
@@ -44,12 +44,16 @@ In the following example you have to set the correct `<orgId>`, `publicKey` and 
 helm install atlas-cluster mongodb/atlas-cluster\
     --namespace=my-cluster \
     --create-namespace  \
+    --values values-sample.yaml \
     --set project.atlasProjectName='My Project' \
     --set atlas.orgId='<orgid>' \
     --set atlas.publicApiKey='<publicKey>' \
     --set atlas.privateApiKey='<privateApiKey>'
 ```
-Note, by default a random password will be generated. You can optionally also pass in a random username, however since this value is shared across templates this must be passed in, for example:
+
+Note, by default a random password will be generated.
+This behavior is controlled in the "values-sample.yaml" you pass to a chart.
+You can optionally also pass in a random username, however since this value is shared across templates this must be passed in, for example:
 
 ```shell
 helm template --set "users[0].username=$(mktemp | cut -f2 -d.)" my-cluster mongodb/atlas-cluster 

--- a/charts/atlas-cluster/templates/atlas-cluster.yaml
+++ b/charts/atlas-cluster/templates/atlas-cluster.yaml
@@ -1,4 +1,5 @@
-{{- range .Values.clusters }}
+{{- with .Values.clusters }}
+{{- range . }}
 ---
 apiVersion: atlas.mongodb.com/v1
 kind: AtlasCluster
@@ -73,5 +74,6 @@ spec:
   {{- with .replicationSpecs }}
   {{- toYaml . | nindent 4 }}
   {{- end }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/atlas-cluster/templates/atlas-mongodb-user-secret.yaml
+++ b/charts/atlas-cluster/templates/atlas-mongodb-user-secret.yaml
@@ -1,5 +1,5 @@
-{{- if .Values.project.create }}
-{{- range .Values.users }}
+{{- with .Values.users }}
+{{- range . }}
 ---
 apiVersion: v1
 kind: Secret

--- a/charts/atlas-cluster/templates/atlas-mongodb-user.yaml
+++ b/charts/atlas-cluster/templates/atlas-mongodb-user.yaml
@@ -1,5 +1,5 @@
-{{- if .Values.project.create }}
-{{- range .Values.users }}
+{{- with .Values.users }}
+{{- range . }}
 ---
 apiVersion: atlas.mongodb.com/v1
 kind: AtlasDatabaseUser

--- a/charts/atlas-cluster/values-sample.yaml
+++ b/charts/atlas-cluster/values-sample.yaml
@@ -1,6 +1,3 @@
-mongodb-atlas-operator:
-  enabled: true
-
 # Please provide Atlas API credentials and Organization
 atlas:
   create: true
@@ -15,7 +12,8 @@ project:
   create: true
   name: my-project
   atlasProjectName: "Test Project"
-  annotations: {}
+  annotations:
+    {}
     # mongodb.com/atlas-resource-policy: keep
   # fullnameOverride: ""
 
@@ -25,7 +23,8 @@ project:
 
 clusters:
   - name: cluster-name
-    annotations: {}
+    annotations:
+      {}
       # mongodb.com/atlas-resource-policy: keep
     providerSettings:
       instanceSizeName: M2

--- a/charts/atlas-cluster/values-sample.yaml
+++ b/charts/atlas-cluster/values-sample.yaml
@@ -1,0 +1,69 @@
+mongodb-atlas-operator:
+  enabled: true
+
+# Please provide Atlas API credentials and Organization
+atlas:
+  create: true
+  existingSecretName: ""
+  orgId: "<Atlas Organization ID>"
+  publicApiKey: "<Atlas_api_public_key>"
+  privateApiKey: "<Atlas_api_private_key>"
+
+  connectionSecretName: ""
+
+project:
+  create: true
+  name: my-project
+  atlasProjectName: "Test Project"
+  annotations: {}
+    # mongodb.com/atlas-resource-policy: keep
+  # fullnameOverride: ""
+
+  projectIpAccessList:
+    - ipAddress: "0.0.0.0/1"
+      comment: "REMOVE ME"
+
+clusters:
+  - name: cluster-name
+    annotations: {}
+      # mongodb.com/atlas-resource-policy: keep
+    providerSettings:
+      instanceSizeName: M2
+      providerName: TENANT
+      backingProviderName: AWS
+      regionName: US_EAST_1
+
+# Optional section. for more information visit
+# https://docs.atlas.mongodb.com/reference/api/clusters-create-one/
+# #
+#   autoScaling:
+#     autoIndexingEnabled: false
+#     compute:
+#       enabled: false
+#       maxInstanceSize: 'M40'
+#       minInstanceSize: 'M10'
+#       scaleDownEnabled: false
+#     diskGBEnabled: false
+#   biConnector:
+#     enabled: false
+#     readPreference: 'primary'
+#   clusterType: 'REPLICASET'
+#   diskSizeGB: '50'
+#   encryptionAtRestProvider: 'AWS'
+#   labels:
+#   mongoDBMajorVersion: '4.4'
+#   numShards: 2
+#   paused: false
+#   pitEnabled: false
+#   providerBackupEnabled: false
+#   replicationSpecs:
+users:
+  - username: admin-user
+    databaseName: admin
+    password:
+    roles:
+      - databaseName: admin
+        roleName: atlasAdmin
+    # deleteAfterDate:
+    # labels:
+    # scopes:

--- a/charts/atlas-cluster/values.yaml
+++ b/charts/atlas-cluster/values.yaml
@@ -1,10 +1,11 @@
-mongodb-atlas-operator:
-  enabled: true
-
 # Please provide Atlas API credentials and Organization
 atlas:
   create: false
   existingSecretName: ""
+  orgId: "<Atlas Organization ID>"
+  publicApiKey: "<Atlas_api_public_key>"
+  privateApiKey: "<Atlas_api_private_key>"
+
   connectionSecretName: ""
 
 project:
@@ -12,12 +13,13 @@ project:
   name: my-project
   atlasProjectName: "Test Project"
   annotations:
-    mongodb.com/atlas-resource-policy: keep
+    {}
+    # mongodb.com/atlas-resource-policy: keep
   # fullnameOverride: ""
 
   projectIpAccessList:
     - ipAddress: "0.0.0.0/1"
       comment: "REMOVE ME"
 
-clusters: [] 
-users: [] 
+clusters: []
+users: []

--- a/charts/atlas-cluster/values.yaml
+++ b/charts/atlas-cluster/values.yaml
@@ -3,72 +3,21 @@ mongodb-atlas-operator:
 
 # Please provide Atlas API credentials and Organization
 atlas:
-  create: true
+  create: false
   existingSecretName: ""
-  orgId: "<Atlas Organization ID>"
-  publicApiKey: "<Atlas_api_public_key>"
-  privateApiKey: "<Atlas_api_private_key>"
-
   connectionSecretName: ""
 
 project:
-  create: true
+  create: false
   name: my-project
   atlasProjectName: "Test Project"
-  annotations: {}
-    # mongodb.com/atlas-resource-policy: keep
+  annotations:
+    mongodb.com/atlas-resource-policy: keep
   # fullnameOverride: ""
 
   projectIpAccessList:
     - ipAddress: "0.0.0.0/1"
       comment: "REMOVE ME"
 
-# Skip clusters creation
-# clusters: [] 
-clusters:
-  - name: cluster-name
-    annotations: {}
-      # mongodb.com/atlas-resource-policy: keep
-    providerSettings:
-      instanceSizeName: M2
-      providerName: TENANT
-      backingProviderName: AWS
-      regionName: US_EAST_1
-
-# Optional section. for more information visit
-# https://docs.atlas.mongodb.com/reference/api/clusters-create-one/
-# #
-#   autoScaling:
-#     autoIndexingEnabled: false
-#     compute:
-#       enabled: false
-#       maxInstanceSize: 'M40'
-#       minInstanceSize: 'M10'
-#       scaleDownEnabled: false
-#     diskGBEnabled: false
-#   biConnector:
-#     enabled: false
-#     readPreference: 'primary'
-#   clusterType: 'REPLICASET'
-#   diskSizeGB: '50'
-#   encryptionAtRestProvider: 'AWS'
-#   labels:
-#   mongoDBMajorVersion: '4.4'
-#   numShards: 2
-#   paused: false
-#   pitEnabled: false
-#   providerBackupEnabled: false
-#   replicationSpecs:
-
-# Skip users creation
-# users: [] 
-users:
-  - username: admin-user
-    databaseName: admin
-    password:
-    roles:
-      - databaseName: admin
-        roleName: atlasAdmin
-    # deleteAfterDate:
-    # labels:
-    # scopes:
+clusters: [] 
+users: [] 

--- a/charts/atlas-cluster/values.yaml
+++ b/charts/atlas-cluster/values.yaml
@@ -23,6 +23,8 @@ project:
     - ipAddress: "0.0.0.0/1"
       comment: "REMOVE ME"
 
+# Skip clusters creation
+# clusters: [] 
 clusters:
   - name: cluster-name
     annotations: {}
@@ -57,6 +59,9 @@ clusters:
 #   pitEnabled: false
 #   providerBackupEnabled: false
 #   replicationSpecs:
+
+# Skip users creation
+# users: [] 
 users:
   - username: admin-user
     databaseName: admin


### PR DESCRIPTION
running `helm helm install atlas-cluster mongodb/atlas-cluster`
without ` -f values-sample.yaml` should do nothing.
Thus protects from human error when people like me have not read docs.
fixes #91 
contains changes from #90 
updates docs