### PR TITLE
Enterprise-operator: Added chart's values to support nodeSelector, tolerations and affinity

### DIFF
--- a/charts/enterprise-operator/templates/operator.yaml
+++ b/charts/enterprise-operator/templates/operator.yaml
@@ -124,6 +124,22 @@ spec:
             defaultMode: 420
             secretName: {{ .Values.multiCluster.kubeConfigSecretName }}
 {{- end }}
+
+{{- with .Values.operator }}
+  {{- with .nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+  {{- end }}
+  {{- with .affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+  {{- end }}
+  {{- with .tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+  {{- end }}
+{{- end }}
+
 {{- if .Values.debug }}
 ---
 apiVersion: v1

--- a/charts/enterprise-operator/values-openshift.yaml
+++ b/charts/enterprise-operator/values-openshift.yaml
@@ -26,6 +26,12 @@ operator:
   - opsmanagers
   - mongodbusers
 
+  nodeSelector: {}
+
+  tolerations: []
+
+  affinity: {}
+
 ## Database
 database:
   name: enterprise-database

--- a/charts/enterprise-operator/values.yaml
+++ b/charts/enterprise-operator/values.yaml
@@ -30,6 +30,12 @@ operator:
   # Create operator-service account
   createOperatorServiceAccount: true
 
+  nodeSelector: {}
+
+  tolerations: []
+
+  affinity: {}
+
 ## Database
 database:
   name: mongodb-enterprise-database


### PR DESCRIPTION
Hi,

Reopening here the PR mongodb/mongodb-enterprise-kubernetes#206

This PR brings the options nodeSelector, tolerations and affinity into values.yaml that gives more control over where the operator is spawned in a cluster.

### All Submissions:

* [x] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

