### PR TITLE
Cluster name release name - DRAFT ONLY

### DIFF
--- a/charts/atlas-cluster/templates/atlas-cluster.yaml
+++ b/charts/atlas-cluster/templates/atlas-cluster.yaml
@@ -3,7 +3,7 @@
 apiVersion: atlas.mongodb.com/v1
 kind: AtlasCluster
 metadata:
-  name: {{ $.Release.Name }}
+  name: {{ $.Release.Name }}-{{ .name }}
   labels:
     {{- include "atlas-cluster.labels" $ | nindent 4 }}
   namespace: {{ $.Release.Namespace }}

--- a/charts/atlas-cluster/templates/atlas-cluster.yaml
+++ b/charts/atlas-cluster/templates/atlas-cluster.yaml
@@ -3,7 +3,7 @@
 apiVersion: atlas.mongodb.com/v1
 kind: AtlasCluster
 metadata:
-  name: {{ .name }}
+  name: {{ $.Release.Name }}
   labels:
     {{- include "atlas-cluster.labels" $ | nindent 4 }}
   namespace: {{ $.Release.Namespace }}
@@ -12,9 +12,9 @@ metadata:
 {{ toYaml .annotations | indent 4 }}
   {{- end }}
 spec:
-  name: {{ include "atlas-cluster.projectfullname" $ }}
+  name: {{ $.Release.Name }}
   projectRef:
-    name: {{ include "atlas-cluster.projectfullname" $ }}
+    name: {{ $.Release.Name }}
   providerSettings:
 {{- with .providerSettings -}}
   {{- $provider := .providerName -}}

--- a/charts/atlas-cluster/templates/atlas-cluster.yaml
+++ b/charts/atlas-cluster/templates/atlas-cluster.yaml
@@ -12,7 +12,7 @@ metadata:
 {{ toYaml .annotations | indent 4 }}
   {{- end }}
 spec:
-  name: {{ .name }}
+  name: {{ include "atlas-cluster.projectfullname" $ }}
   projectRef:
     name: {{ include "atlas-cluster.projectfullname" $ }}
   providerSettings:

--- a/charts/atlas-cluster/templates/atlas-cluster.yaml
+++ b/charts/atlas-cluster/templates/atlas-cluster.yaml
@@ -12,7 +12,7 @@ metadata:
 {{ toYaml .annotations | indent 4 }}
   {{- end }}
 spec:
-  name: {{ $.Release.Name }}
+  name: {{ $.Release.Name }}-{{ .name }}
   projectRef:
     name: {{ $.Release.Name }}
   providerSettings:

--- a/charts/atlas-cluster/templates/atlas-mongodb-user.yaml
+++ b/charts/atlas-cluster/templates/atlas-mongodb-user.yaml
@@ -4,7 +4,7 @@
 apiVersion: atlas.mongodb.com/v1
 kind: AtlasDatabaseUser
 metadata:
-  name: {{ include "atlas-cluster.fullname" $ }}-{{ .username }}
+  name: {{ $.Release.Name }}-{{ .username }}
   namespace: {{ $.Release.Namespace }}
   labels:
     {{- include "atlas-cluster.labels" $ | nindent 4 }}
@@ -14,7 +14,7 @@ spec:
   passwordSecretRef:
     name: {{ include "atlas-cluster.fullname" $ }}-{{ .username }}
   projectRef:
-    name: {{ include "atlas-cluster.projectfullname" $ }}
+    name: {{ $.Release.Name }}
   roles:
     {{- toYaml .roles | nindent 4 }}
   {{- if .deleteAfterDate }}

--- a/charts/atlas-cluster/templates/atlas-project.yaml
+++ b/charts/atlas-cluster/templates/atlas-project.yaml
@@ -2,7 +2,7 @@
 apiVersion: atlas.mongodb.com/v1
 kind: AtlasProject
 metadata:
-  name: {{ include "atlas-cluster.projectfullname" . }}
+  name: {{ $.Release.Name }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "atlas-cluster.labels" . | nindent 4 }}
@@ -11,7 +11,7 @@ metadata:
 {{ toYaml .Values.project.annotations | indent 4 }}
   {{- end }}
 spec:
-  name: {{ .Values.project.atlasProjectName }}
+  name: {{ $.Release.Name }}
   connectionSecretRef:
 {{- if .Values.atlas.connectionSecretName }}
     name: {{ .Values.atlas.connectionSecretName}}

--- a/charts/atlas-cluster/values.yaml
+++ b/charts/atlas-cluster/values.yaml
@@ -14,7 +14,7 @@ atlas:
 project:
   create: true
   annotations: {}
-  # mongodb.com/atlas-resource-policy: keep
+    # mongodb.com/atlas-resource-policy: keep
   # fullnameOverride: ""
 
   projectIpAccessList:
@@ -22,7 +22,7 @@ project:
       comment: "REMOVE ME"
 
 clusters:
-  - name: cluster-name
+  - name: cluster-1
     annotations: {}
       # mongodb.com/atlas-resource-policy: keep
     providerSettings:

--- a/charts/atlas-cluster/values.yaml
+++ b/charts/atlas-cluster/values.yaml
@@ -13,10 +13,8 @@ atlas:
 
 project:
   create: true
-  name: my-project
-  atlasProjectName: "Test Project"
   annotations: {}
-    # mongodb.com/atlas-resource-policy: keep
+  # mongodb.com/atlas-resource-policy: keep
   # fullnameOverride: ""
 
   projectIpAccessList:


### PR DESCRIPTION
Hi-

This is a draft for comment. To make things easier, the `atlas-cluster` chart should default the name of the Atlas Project and Cluster to the name of the Helm release.