### PR TITLE
Fixed operator's role bindings to be bond correctly

### DIFF
--- a/charts/community-operator/templates/operator_roles.yaml
+++ b/charts/community-operator/templates/operator_roles.yaml
@@ -64,6 +64,8 @@ metadata:
   name: {{ .Values.operator.name }}
   {{- if ne (.Values.operator.watchNamespace | default "*") "*" }}
   namespace: {{ .Values.operator.watchNamespace }}
+  {{- else }}
+  namespace: {{ .Release.Namespace }}
   {{- end }}
 subjects:
 - kind: ServiceAccount

--- a/charts/community-operator/templates/operator_roles.yaml
+++ b/charts/community-operator/templates/operator_roles.yaml
@@ -64,15 +64,15 @@ kind: {{ if eq (.Values.operator.watchNamespace | default "") "*" }} ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ .Values.operator.name }}
-  {{- if .Values.namespace }}
-  namespace: {{ .Values.namespace }}
+  {{- if ne (.Values.operator.watchNamespace | default "*") "*" }}
+  namespace: {{ .Values.operator.watchNamespace }}
   {{- end }}
 subjects:
 - kind: ServiceAccount
   name: {{ .Values.operator.name }}
-{{ if eq (.Values.operator.watchNamespace | default "") "*" }}
+  {{- if .Values.namespace }}
   namespace: {{ .Values.namespace }}
-{{ end }}
+  {{- end }}
 roleRef:
   kind: {{ if eq (.Values.operator.watchNamespace | default "") "*" }} ClusterRole {{ else }} Role {{ end }}
   name: {{ .Values.operator.name }}


### PR DESCRIPTION
Hi team, we found that the latest "community-operator" (v0.7.2) does not correctly set permissions for operators when ".Values.operator.watchNamespace" is specified other than '*'.

I have created a PR to fix the problem, so please merge it if it is good.

[issue] When set '.Values.operator.watchNamespace as "mongodb"
----------

The following error will be output repeatedly in the operator's pod.

```
mongodb-kubernetes-operator-6f78bf7bfb-r88sr mongodb-kubernetes-operator E1221 14:35:40.670485       9 reflector.go:138] pkg/mod/k8s.io/client-go@v0.22.3/tools/cache/reflector.go:167: Failed to watch *v1.StatefulSet: failed to list *v1.StatefulSet: statefulsets.apps is forbidden: User "system:serviceaccount:mongodb-operator:mongodb-kubernetes-operator" cannot list resource "statefulsets" in API group "apps" in the namespace "mongodb"
mongodb-kubernetes-operator-6f78bf7bfb-r88sr mongodb-kubernetes-operator E1221 14:43:26.285357       9 reflector.go:138] pkg/mod/k8s.io/client-go@v0.22.3/tools/cache/reflector.go:167: Failed to watch *v1.MongoDBCommunity: failed to list *v1.MongoDBCommunity: mongodbcommunity.mongodbcommunity.mongodb.com is forbidden: User "system:serviceaccount:mongodb-operator:mongodb-kubernetes-operator" cannot list resource "mongodbcommunity" in API group "mongodbcommunity.mongodb.com" in the namespace "mongodb"
  : <snip> repeat
```

The cause is that the operator role binding (named "mongodb-kubernetes-operator") incorrectly specifies the namespace of the service account.

[solve] What a pull request solves
----------

Depending on the combination of ".Values.operator.watchNamespace" and ".Values.namespace" values, the correct role binding can be created.


| namespace where helm release is installed<br/>(old: .Values.namespace) | .Values.operator.watchNamespace | SA's namespace<br>(mongodb-kubernetes-operator) | CRB/RB<br>(mongodb-kubernetes-operator) |
|:-----------------:|:-------------------------------:|:-------------------------------------------:|:----------------------------------------:|
| mongodb-operator  | mongodb                         | mongodb-operator                            | [1]                                      |
| mongodb-operator  | *                               | mongodb-operator                            | [2]                                      |
| mongodb-operator  | mongodb-operator                | mongodb-operator                            | [3]                                      |
| mongodb-operator  | - (not specified)  | mongodb-operator                            | [3]                                      |

* legend
    * SA: ServiceAccount
    * CRB: ClusterRoleBinding
    * RB: RoleBinding

[1]

```yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: RoleBinding
metadata:
  name: mongodb-kubernetes-operator
  namespace: mongodb
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: Role
  name: mongodb-kubernetes-operator
subjects:
- kind: ServiceAccount
  name: mongodb-kubernetes-operator
  namespace: mongodb-operator
```

[2]

```yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRoleBinding
metadata:
  name: mongodb-kubernetes-operator
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: ClusterRole
  name: mongodb-kubernetes-operator
subjects:
- kind: ServiceAccount
  name: mongodb-kubernetes-operator
  namespace: mongodb-operator
```

[3]

```yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: RoleBinding
metadata:
  name: mongodb-kubernetes-operator
  namespace: mongodb-operator
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: Role
  name: mongodb-kubernetes-operator
subjects:
- kind: ServiceAccount
  name: mongodb-kubernetes-operator
  namespace: mongodb-operator
```
