### PR TITLE
Add credentials label to helm chart

### DIFF
--- a/charts/atlas-cluster/templates/atlas-mongodb-user-secret.yaml
+++ b/charts/atlas-cluster/templates/atlas-mongodb-user-secret.yaml
@@ -7,6 +7,7 @@ metadata:
   name: {{ include "atlas-cluster.fullname" $ }}-{{ .username }}
   namespace: {{ $.Release.Namespace }}
   labels:
+    atlas.mongodb.com/type: "credentials"
     {{- include "atlas-cluster.labels" $ | nindent 4 }}
 type: Opaque
 stringData:

--- a/charts/atlas-cluster/templates/atlas-secret.yaml
+++ b/charts/atlas-cluster/templates/atlas-secret.yaml
@@ -10,6 +10,7 @@ metadata:
 {{- end }}
   namespace: {{ .Release.Namespace }}
   labels:
+    atlas.mongodb.com/type: "credentials"
     {{- include "atlas-cluster.labels" . | nindent 4 }}
   annotations:
     'helm.sh/hook': post-delete,pre-install,pre-upgrade

--- a/charts/atlas-operator/templates/global-secret.yaml
+++ b/charts/atlas-operator/templates/global-secret.yaml
@@ -5,7 +5,7 @@ type: Opaque
 metadata:
   name: "{{ include "mongodb-atlas-operator.name" . }}-api-key"
   labels:
-    "atlas.mongodb.com/type": "credentials"
+    atlas.mongodb.com/type: "credentials"
     {{- include "mongodb-atlas-operator.labels" . | nindent 4 }}
 data:
     orgId: {{ .Values.globalConnectionSecret.orgId| b64enc }}

--- a/charts/atlas-operator/templates/global-secret.yaml
+++ b/charts/atlas-operator/templates/global-secret.yaml
@@ -5,6 +5,7 @@ type: Opaque
 metadata:
   name: "{{ include "mongodb-atlas-operator.name" . }}-api-key"
   labels:
+    "atlas.mongodb.com/type": "credentials"
     {{- include "mongodb-atlas-operator.labels" . | nindent 4 }}
 data:
     orgId: {{ .Values.globalConnectionSecret.orgId| b64enc }}


### PR DESCRIPTION
The next version of the Atlas Operator requires secrets to be labelled with `atlas.mongodb.com/type=credentials"`  for the operator to watch them. This PR adds this label to the secrets generated by the helm chart.