### PR TITLE
Add clusterwide field to helm chart

### DIFF
--- a/charts/atlas-cluster/templates/atlas-project.yaml
+++ b/charts/atlas-cluster/templates/atlas-project.yaml
@@ -12,7 +12,7 @@ metadata:
   {{- end }}
 spec:
   name: {{ .Values.project.atlasProjectName }}
-{{- if (not .Values.mongodb-atlas-operator.clusterWide) }}
+{{- if (not ".Values.mongodb-atlas-operator.clusterWide") }}
   connectionSecretRef:
 {{- if .Values.atlas.connectionSecretName }}
     name: {{ .Values.atlas.connectionSecretName}}

--- a/charts/atlas-cluster/templates/atlas-project.yaml
+++ b/charts/atlas-cluster/templates/atlas-project.yaml
@@ -12,6 +12,7 @@ metadata:
   {{- end }}
 spec:
   name: {{ .Values.project.atlasProjectName }}
+{{- if ( not .Values.mongodb-atlas-operator.clusterWide) }}
   connectionSecretRef:
 {{- if .Values.atlas.connectionSecretName }}
     name: {{ .Values.atlas.connectionSecretName}}
@@ -19,6 +20,7 @@ spec:
     name: {{ .Values.atlas.existingSecretName }}
 {{- else }}
     name: {{ include "atlas-cluster.fullname" . }}-secret
+{{- end }}
 {{- end }}
   projectIpAccessList:
   {{- with .Values.project.projectIpAccessList }}

--- a/charts/atlas-cluster/templates/atlas-project.yaml
+++ b/charts/atlas-cluster/templates/atlas-project.yaml
@@ -12,7 +12,7 @@ metadata:
   {{- end }}
 spec:
   name: {{ .Values.project.atlasProjectName }}
-{{- if ( not .Values.mongodb-atlas-operator.clusterWide) }}
+{{- if (not .Values.mongodb-atlas-operator.clusterWide) }}
   connectionSecretRef:
 {{- if .Values.atlas.connectionSecretName }}
     name: {{ .Values.atlas.connectionSecretName}}

--- a/charts/atlas-cluster/values.yaml
+++ b/charts/atlas-cluster/values.yaml
@@ -1,5 +1,6 @@
 mongodb-atlas-operator:
   enabled: true
+  clusterWide: false
 
 # Please provide Atlas API credentials and Organization
 atlas:


### PR DESCRIPTION
This PR adds a new field `clusterWide` which indicates that you are deploying a cluster using a cluster scoped operator. Installation looks like this.


```bash

# install operator
helm install atlas-operator mongodb/mongodb-atlas-operator \
    --namespace=atlas-operator \
    --create-namespace \
    --set globalConnectionSecret.publicApiKey=<the_public_key> \
    --set globalConnectionSecret.privateApiKey=<the_private_key> \
    --set globalConnectionSecret.orgId=<the_org_id>

# deploy cluster
helm install atlas-cluster --namespace=my-cluster  --create-namespace  --set project.atlasProjectName='My Project' --set mongodb-atlas-operator.clusterWide=true ./atlas-cluster/
```

Note: no credentials are required when deploying the cluster wide resources.
