### PR TITLE
Use mongodbAtlasOperator instead of mongodb-atlas-operator

### DIFF
--- a/charts/atlas-cluster/templates/atlas-project.yaml
+++ b/charts/atlas-cluster/templates/atlas-project.yaml
@@ -12,7 +12,7 @@ metadata:
   {{- end }}
 spec:
   name: {{ .Values.project.atlasProjectName }}
-{{- if (not ".Values.mongodb-atlas-operator.clusterWide") }}
+{{- if not .Values.mongodbAtlasOperator.clusterWide }}
   connectionSecretRef:
 {{- if .Values.atlas.connectionSecretName }}
     name: {{ .Values.atlas.connectionSecretName}}

--- a/charts/atlas-cluster/values.yaml
+++ b/charts/atlas-cluster/values.yaml
@@ -1,4 +1,4 @@
-mongodb-atlas-operator:
+mongodbAtlasOperator:
   enabled: true
   clusterWide: false
 


### PR DESCRIPTION
We need to rename mongodb-atlas-operator to mongodbAtlasOperator. Due to the issue outlined here https://github.com/helm/helm/issues/2192

The use case there is slightly different, but it is generally [recommended](https://helm.sh/docs/chart_best_practices/values/#naming-conventions) to use camelCase for objects in values.yaml (dashes are okay for helm chart names)

I had introduced a bug previously where a the string value was always being evaluated to false, so this chart did not work as intended. This PR fixes that issue and changes the name of the object in values.yaml.