### PR TITLE
[atlas-operator]: metrics listen :8080

### DIFF
--- a/charts/atlas-operator/templates/deployment.yaml
+++ b/charts/atlas-operator/templates/deployment.yaml
@@ -31,7 +31,7 @@ spec:
           args:
             - --atlas-domain={{ .Values.atlasURI }}
             - "--health-probe-bind-address=:8081"
-            - "--metrics-bind-address=127.0.0.1:8080"
+            - "--metrics-bind-address=:8080"
             - "--leader-elect"
           command:
             - /manager


### PR DESCRIPTION
metrics are not scrapable on 127.0.0.1 this is a holdover when the rbac proxy fronted this endpoint.