### PR TITLE
Add support for advanced cluster

### DIFF
--- a/charts/atlas-cluster/templates/atlas-cluster.yaml
+++ b/charts/atlas-cluster/templates/atlas-cluster.yaml
@@ -12,68 +12,69 @@ metadata:
 {{ toYaml .annotations | indent 4 }}
   {{- end }}
 spec:
-  name: {{ .name }}
   projectRef:
     name: {{ include "atlas-cluster.projectfullname" $ }}
-  providerSettings:
-{{- with .providerSettings -}}
-  {{- $provider := .providerName -}}
-  {{- range $key, $val := . }}
-  {{ if or (ne $key "backingProviderName") (and (eq $key "backingProviderName") (eq $provider "TENANT" )) }}
-    {{- $key | indent 2 }}: {{ $val }}
+  clusterSpec:
+    name: {{ .name }}
+    providerSettings:
+  {{- with .providerSettings -}}
+    {{- $provider := .providerName -}}
+    {{- range $key, $val := . }}
+    {{ if or (ne $key "backingProviderName") (and (eq $key "backingProviderName") (eq $provider "TENANT" )) }}
+      {{- $key | indent 2 }}: {{ $val }}
+    {{- end }}
+    {{- end }}
   {{- end }}
-  {{- end }}
-{{- end }}
-{{- if .autoScaling }}
-  autoScaling:
-{{- with .autoScaling }}
-{{- toYaml . | nindent 4 }}
-{{- end }}
-{{- end }}
-{{- if .autoIndexingEnabled }}
-    autoIndexingEnabled: false
-{{- end }}
-{{- if .biConnector }}
-  biConnector:
-    enabled: {{ .biConnector.enabled }}
-    readPreference: {{ .biConnector.readPreference }}
-{{- end }}
-{{- if .clusterType }}
-  clusterType: {{ .clusterType }}
-{{- end }}
-{{- if .diskSizeGB }}
-  diskSizeGB: {{ .diskSizeGB }}
-{{- end }}
-{{- if .encryptionAtRestProvider }}
-  encryptionAtRestProvider: {{ .encryptionAtRestProvider }}
-{{- end }}
-{{- if .labels }}
-  labels:
-  {{- with .labels }}
+  {{- if .autoScaling }}
+    autoScaling:
+  {{- with .autoScaling }}
   {{- toYaml . | nindent 4 }}
   {{- end }}
-{{- end }}
-{{- if .mongoDBMajorVersion }}
-  mongoDBMajorVersion: {{ .mongoDBMajorVersion }}
-{{- end }}
-{{- if .numShards }}
-  numShards: {{ .numShards }}
-{{- end }}
-{{- if .paused }}
-  paused: {{ .paused }}
-{{- end }}
-{{- if .pitEnabled }}
-  pitEnabled: {{ .pitEnabled }}
-{{- end }}
-{{- if .providerBackupEnabled }}
-  providerBackupEnabled: {{ .providerBackupEnabled }}
-{{- end }}
-{{- if .replicationSpecs }}
-  replicationSpecs:
-  {{- with .replicationSpecs }}
-  {{- toYaml . | nindent 4 }}
   {{- end }}
-{{- end }}
+  {{- if .autoIndexingEnabled }}
+      autoIndexingEnabled: false
+  {{- end }}
+  {{- if .biConnector }}
+    biConnector:
+      enabled: {{ .biConnector.enabled }}
+      readPreference: {{ .biConnector.readPreference }}
+  {{- end }}
+  {{- if .clusterType }}
+    clusterType: {{ .clusterType }}
+  {{- end }}
+  {{- if .diskSizeGB }}
+    diskSizeGB: {{ .diskSizeGB }}
+  {{- end }}
+  {{- if .encryptionAtRestProvider }}
+    encryptionAtRestProvider: {{ .encryptionAtRestProvider }}
+  {{- end }}
+  {{- if .labels }}
+    labels:
+    {{- with .labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
+  {{- if .mongoDBMajorVersion }}
+    mongoDBMajorVersion: {{ .mongoDBMajorVersion }}
+  {{- end }}
+  {{- if .numShards }}
+    numShards: {{ .numShards }}
+  {{- end }}
+  {{- if .paused }}
+    paused: {{ .paused }}
+  {{- end }}
+  {{- if .pitEnabled }}
+    pitEnabled: {{ .pitEnabled }}
+  {{- end }}
+  {{- if .providerBackupEnabled }}
+    providerBackupEnabled: {{ .providerBackupEnabled }}
+  {{- end }}
+  {{- if .replicationSpecs }}
+    replicationSpecs:
+    {{- with .replicationSpecs }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
 
 {{- if $.Values.postInstallHook.enabled }}
 ---

--- a/charts/atlas-cluster/templates/atlas-cluster.yaml
+++ b/charts/atlas-cluster/templates/atlas-cluster.yaml
@@ -1,5 +1,3 @@
-#{{- $root := . -}}
-
 {{- range .Values.clusters }}
 ---
 apiVersion: atlas.mongodb.com/v1

--- a/charts/atlas-cluster/templates/atlas-cluster.yaml
+++ b/charts/atlas-cluster/templates/atlas-cluster.yaml
@@ -1,9 +1,15 @@
+#{{- $root := . -}}
+
 {{- range .Values.clusters }}
 ---
 apiVersion: atlas.mongodb.com/v1
 kind: AtlasCluster
 metadata:
+  {{- if .advancedClusterSpec }}
+  name: {{ .advancedClusterSpec.name }}
+  {{- else if .clusterSpec }}
   name: {{ .clusterSpec.name }}
+  {{- end }}
   labels:
     {{- include "atlas-cluster.labels" $ | nindent 4 }}
   namespace: {{ $.Release.Namespace }}
@@ -14,6 +20,7 @@ metadata:
 spec:
   projectRef:
     name: {{ include "atlas-cluster.projectfullname" $ }}
+  {{- if .clusterSpec }}
   clusterSpec:
     name: {{ .clusterSpec.name }}
     providerSettings:
@@ -74,6 +81,11 @@ spec:
     {{- with .clusterSpec.replicationSpecs }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
+  {{- end }}
+  {{- end }}
+  {{- if .advancedClusterSpec }}
+  advancedClusterSpec:
+  {{- toYaml .advancedClusterSpec | nindent 4}}
   {{- end }}
 
 {{- if $.Values.postInstallHook.enabled }}

--- a/charts/atlas-cluster/templates/atlas-cluster.yaml
+++ b/charts/atlas-cluster/templates/atlas-cluster.yaml
@@ -3,7 +3,7 @@
 apiVersion: atlas.mongodb.com/v1
 kind: AtlasCluster
 metadata:
-  name: {{ .name }}
+  name: {{ .clusterSpec.name }}
   labels:
     {{- include "atlas-cluster.labels" $ | nindent 4 }}
   namespace: {{ $.Release.Namespace }}
@@ -15,9 +15,9 @@ spec:
   projectRef:
     name: {{ include "atlas-cluster.projectfullname" $ }}
   clusterSpec:
-    name: {{ .name }}
+    name: {{ .clusterSpec.name }}
     providerSettings:
-  {{- with .providerSettings -}}
+  {{- with .clusterSpec.providerSettings -}}
     {{- $provider := .providerName -}}
     {{- range $key, $val := . }}
     {{ if or (ne $key "backingProviderName") (and (eq $key "backingProviderName") (eq $provider "TENANT" )) }}
@@ -25,7 +25,7 @@ spec:
     {{- end }}
     {{- end }}
   {{- end }}
-  {{- if .autoScaling }}
+  {{- if .clusterSpec.autoScaling }}
     autoScaling:
   {{- with .autoScaling }}
   {{- toYaml . | nindent 4 }}
@@ -34,44 +34,44 @@ spec:
   {{- if .autoIndexingEnabled }}
       autoIndexingEnabled: false
   {{- end }}
-  {{- if .biConnector }}
+  {{- if .clusterSpec.biConnector }}
     biConnector:
-      enabled: {{ .biConnector.enabled }}
-      readPreference: {{ .biConnector.readPreference }}
+      enabled: {{ .clusterSpec.biConnector.enabled }}
+      readPreference: {{ .clusterSpec.biConnector.readPreference }}
   {{- end }}
-  {{- if .clusterType }}
-    clusterType: {{ .clusterType }}
+  {{- if .clusterSpec.clusterType }}
+    clusterType: {{ .clusterSpec.clusterType }}
   {{- end }}
-  {{- if .diskSizeGB }}
-    diskSizeGB: {{ .diskSizeGB }}
+  {{- if .clusterSpec.diskSizeGB }}
+    diskSizeGB: {{ .clusterSpec.diskSizeGB }}
   {{- end }}
-  {{- if .encryptionAtRestProvider }}
-    encryptionAtRestProvider: {{ .encryptionAtRestProvider }}
+  {{- if .clusterSpec.encryptionAtRestProvider }}
+    encryptionAtRestProvider: {{ .clusterSpec.encryptionAtRestProvider }}
   {{- end }}
-  {{- if .labels }}
+  {{- if .clusterSpec.labels }}
     labels:
-    {{- with .labels }}
+    {{- with .clusterSpec.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
   {{- end }}
-  {{- if .mongoDBMajorVersion }}
-    mongoDBMajorVersion: {{ .mongoDBMajorVersion }}
+  {{- if .clusterSpec.mongoDBMajorVersion }}
+    mongoDBMajorVersion: {{ .clusterSpec.mongoDBMajorVersion }}
   {{- end }}
-  {{- if .numShards }}
-    numShards: {{ .numShards }}
+  {{- if .clusterSpec.numShards }}
+    numShards: {{ .clusterSpec.numShards }}
   {{- end }}
-  {{- if .paused }}
-    paused: {{ .paused }}
+  {{- if .clusterSpec.paused }}
+    paused: {{ .clusterSpec.paused }}
   {{- end }}
-  {{- if .pitEnabled }}
-    pitEnabled: {{ .pitEnabled }}
+  {{- if .clusterSpec.pitEnabled }}
+    pitEnabled: {{ .clusterSpec.pitEnabled }}
   {{- end }}
-  {{- if .providerBackupEnabled }}
-    providerBackupEnabled: {{ .providerBackupEnabled }}
+  {{- if .clusterSpec.providerBackupEnabled }}
+    providerBackupEnabled: {{ .clusterSpec.providerBackupEnabled }}
   {{- end }}
-  {{- if .replicationSpecs }}
+  {{- if .clusterSpec.replicationSpecs }}
     replicationSpecs:
-    {{- with .replicationSpecs }}
+    {{- with .clusterSpec.replicationSpecs }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
   {{- end }}

--- a/charts/atlas-cluster/values.yaml
+++ b/charts/atlas-cluster/values.yaml
@@ -32,6 +32,9 @@ project:
     - ipAddress: "0.0.0.0/1"
       comment: "REMOVE ME"
 
+# include either clusterSpec or advancedClusterSpec
+# see https://docs.atlas.mongodb.com/reference/api/cluster-advanced/create-one-cluster-advanced/ for
+# options for creating advanced clusters.
 clusters:
   - clusterSpec:
       name: cluster-name
@@ -42,6 +45,18 @@ clusters:
         providerName: TENANT
         backingProviderName: AWS
         regionName: US_EAST_1
+
+#  - advancedClusterSpec:
+#      clusterType: REPLICASET
+#      name: advanced-cluster
+#      replicationSpecs:
+#        - regionConfigs:
+#            - electableSpecs:
+#                instanceSize: M5
+#              providerName: TENANT
+#              backingProviderName: AWS
+#              regionName: US_EAST_1
+
 
 # Optional section. for more information visit
 # https://docs.atlas.mongodb.com/reference/api/clusters-create-one/

--- a/charts/atlas-cluster/values.yaml
+++ b/charts/atlas-cluster/values.yaml
@@ -33,14 +33,15 @@ project:
       comment: "REMOVE ME"
 
 clusters:
-  - name: cluster-name
-    annotations: {}
-      # mongodb.com/atlas-resource-policy: keep
-    providerSettings:
-      instanceSizeName: M2
-      providerName: TENANT
-      backingProviderName: AWS
-      regionName: US_EAST_1
+  - clusterSpec:
+      name: cluster-name
+      annotations: {}
+        # mongodb.com/atlas-resource-policy: keep
+      providerSettings:
+        instanceSizeName: M2
+        providerName: TENANT
+        backingProviderName: AWS
+        regionName: US_EAST_1
 
 # Optional section. for more information visit
 # https://docs.atlas.mongodb.com/reference/api/clusters-create-one/
@@ -66,10 +67,6 @@ clusters:
 #   pitEnabled: false
 #   providerBackupEnabled: false
 #   replicationSpecs:
-
-#advancedClusters:
-#  - name: cluster-name
-#    annotations: {}
 
 
 users:

--- a/charts/atlas-cluster/values.yaml
+++ b/charts/atlas-cluster/values.yaml
@@ -57,8 +57,6 @@ clusters:
 #              backingProviderName: AWS
 #              regionName: US_EAST_1
 
-
-
 # Additional clusterSpec values
 # Optional section. for more information visit
 # https://docs.atlas.mongodb.com/reference/api/clusters-create-one/

--- a/charts/atlas-cluster/values.yaml
+++ b/charts/atlas-cluster/values.yaml
@@ -66,6 +66,12 @@ clusters:
 #   pitEnabled: false
 #   providerBackupEnabled: false
 #   replicationSpecs:
+
+#advancedClusters:
+#  - name: cluster-name
+#    annotations: {}
+
+
 users:
   - username: admin-user
     databaseName: admin

--- a/charts/atlas-cluster/values.yaml
+++ b/charts/atlas-cluster/values.yaml
@@ -58,6 +58,8 @@ clusters:
 #              regionName: US_EAST_1
 
 
+
+# Additional clusterSpec values
 # Optional section. for more information visit
 # https://docs.atlas.mongodb.com/reference/api/clusters-create-one/
 # #
@@ -82,8 +84,6 @@ clusters:
 #   pitEnabled: false
 #   providerBackupEnabled: false
 #   replicationSpecs:
-
-
 users:
   - username: admin-user
     databaseName: admin

--- a/charts/atlas-operator-crds/templates/atlas.mongodb.com_atlasclusters.yaml
+++ b/charts/atlas-operator-crds/templates/atlas.mongodb.com_atlasclusters.yaml
@@ -36,145 +36,232 @@ spec:
           spec:
             description: AtlasClusterSpec defines the desired state of AtlasCluster
             properties:
-              autoScaling:
-                description: Collection of settings that configures auto-scaling information
-                  for the cluster. If you specify the autoScaling object, you must
-                  also specify the providerSettings.autoScaling object.
+              advancedClusterSpec:
+                description: Configuration for the advanced cluster API. https://docs.atlas.mongodb.com/reference/api/clusters-advanced/
                 properties:
-                  autoIndexingEnabled:
-                    description: Flag that indicates whether autopilot mode for Performance
-                      Advisor is enabled. The default is false.
+                  backupEnabled:
                     type: boolean
-                  compute:
-                    description: Collection of settings that configure how a cluster
-                      might scale its cluster tier and whether the cluster can scale
-                      down.
+                  biConnector:
+                    description: BiConnectorSpec specifies BI Connector for Atlas
+                      configuration on this cluster
                     properties:
                       enabled:
-                        description: Flag that indicates whether cluster tier auto-scaling
-                          is enabled. The default is false.
+                        description: Flag that indicates whether or not BI Connector
+                          for Atlas is enabled on the cluster.
                         type: boolean
-                      maxInstanceSize:
-                        description: 'Maximum instance size to which your cluster
-                          can automatically scale (such as M40). Atlas requires this
-                          parameter if "autoScaling.compute.enabled" : true.'
+                      readPreference:
+                        description: Source from which the BI Connector for Atlas
+                          reads data. Each BI Connector for Atlas read preference
+                          contains a distinct combination of readPreference and readPreferenceTags
+                          options.
                         type: string
-                      minInstanceSize:
-                        description: 'Minimum instance size to which your cluster
-                          can automatically scale (such as M10). Atlas requires this
-                          parameter if "autoScaling.compute.scaleDownEnabled" : true.'
-                        type: string
-                      scaleDownEnabled:
-                        description: 'Flag that indicates whether the cluster tier
-                          may scale down. Atlas requires this parameter if "autoScaling.compute.enabled"
-                          : true.'
-                        type: boolean
                     type: object
-                  diskGBEnabled:
-                    description: Flag that indicates whether disk auto-scaling is
-                      enabled. The default is true.
-                    type: boolean
-                type: object
-              biConnector:
-                description: Configuration of BI Connector for Atlas on this cluster.
-                  The MongoDB Connector for Business Intelligence for Atlas (BI Connector)
-                  is only available for M10 and larger clusters.
-                properties:
-                  enabled:
-                    description: Flag that indicates whether or not BI Connector for
-                      Atlas is enabled on the cluster.
-                    type: boolean
-                  readPreference:
-                    description: Source from which the BI Connector for Atlas reads
-                      data. Each BI Connector for Atlas read preference contains a
-                      distinct combination of readPreference and readPreferenceTags
-                      options.
+                  clusterType:
                     type: string
-                type: object
-              clusterType:
-                description: Type of the cluster that you want to create. The parameter
-                  is required if replicationSpecs are set or if Global Clusters are
-                  deployed.
-                enum:
-                - REPLICASET
-                - SHARDED
-                - GEOSHARDED
-                type: string
-              diskSizeGB:
-                description: Capacity, in gigabytes, of the host's root volume. Increase
-                  this number to add capacity, up to a maximum possible value of 4096
-                  (i.e., 4 TB). This value must be a positive integer. The parameter
-                  is required if replicationSpecs are configured.
-                maximum: 4096
-                minimum: 0
-                type: integer
-              encryptionAtRestProvider:
-                description: Cloud service provider that offers Encryption at Rest.
-                enum:
-                - AWS
-                - GCP
-                - AZURE
-                - NONE
-                type: string
-              labels:
-                description: Collection of key-value pairs that tag and categorize
-                  the cluster. Each key and value has a maximum length of 255 characters.
-                items:
-                  description: LabelSpec contains key-value pairs that tag and categorize
-                    the Cluster/DBUser
-                  properties:
-                    key:
-                      maxLength: 255
-                      type: string
-                    value:
-                      type: string
-                  required:
-                  - key
-                  - value
-                  type: object
-                type: array
-              mongoDBMajorVersion:
-                description: Version of the cluster to deploy.
-                type: string
-              name:
-                description: Name of the cluster as it appears in Atlas. After Atlas
-                  creates the cluster, you can't change its name.
-                type: string
-              numShards:
-                description: Positive integer that specifies the number of shards
-                  to deploy for a sharded cluster. The parameter is required if replicationSpecs
-                  are configured
-                maximum: 50
-                minimum: 1
-                type: integer
-              paused:
-                description: Flag that indicates whether the cluster should be paused.
-                type: boolean
-              pitEnabled:
-                description: Flag that indicates the cluster uses continuous cloud
-                  backups.
-                type: boolean
-              projectRef:
-                description: Project is a reference to AtlasProject resource the cluster
-                  belongs to
-                properties:
+                  connectionStrings:
+                    description: ConnectionStrings configuration for applications
+                      use to connect to this cluster.
+                    properties:
+                      awsPrivateLink:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      awsPrivateLinkSrv:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      private:
+                        type: string
+                      privateEndpoint:
+                        items:
+                          description: PrivateEndpointSpec connection strings. Each
+                            object describes the connection strings you can use to
+                            connect to this cluster through a private endpoint. Atlas
+                            returns this parameter only if you deployed a private
+                            endpoint to all regions to which you deployed this cluster's
+                            nodes.
+                          properties:
+                            connectionString:
+                              type: string
+                            endpoints:
+                              items:
+                                description: EndpointSpec through which you connect
+                                  to Atlas.
+                                properties:
+                                  endpointId:
+                                    type: string
+                                  providerName:
+                                    type: string
+                                  region:
+                                    type: string
+                                type: object
+                              type: array
+                            srvConnectionString:
+                              type: string
+                            type:
+                              type: string
+                          type: object
+                        type: array
+                      privateSrv:
+                        type: string
+                      standard:
+                        type: string
+                      standardSrv:
+                        type: string
+                    type: object
+                  createDate:
+                    type: string
+                  diskSizeGB:
+                    type: integer
+                  encryptionAtRestProvider:
+                    type: string
+                  groupId:
+                    type: string
+                  id:
+                    type: string
+                  labels:
+                    items:
+                      description: LabelSpec contains key-value pairs that tag and
+                        categorize the Cluster/DBUser
+                      properties:
+                        key:
+                          maxLength: 255
+                          type: string
+                        value:
+                          type: string
+                      required:
+                      - key
+                      - value
+                      type: object
+                    type: array
+                  mongoDBMajorVersion:
+                    type: string
+                  mongoDBVersion:
+                    type: string
                   name:
-                    description: Name is the name of the Kubernetes Resource
                     type: string
-                required:
-                - name
+                  paused:
+                    type: boolean
+                  pitEnabled:
+                    type: boolean
+                  replicationSpecs:
+                    items:
+                      properties:
+                        id:
+                          type: string
+                        numShards:
+                          type: integer
+                        regionConfigs:
+                          items:
+                            properties:
+                              analyticsSpecs:
+                                properties:
+                                  diskIOPS:
+                                    format: int64
+                                    type: integer
+                                  ebsVolumeType:
+                                    type: string
+                                  instanceSize:
+                                    type: string
+                                  nodeCount:
+                                    type: integer
+                                type: object
+                              autoScaling:
+                                description: AutoScalingSpec configures your cluster
+                                  to automatically scale its storage
+                                properties:
+                                  autoIndexingEnabled:
+                                    description: Flag that indicates whether autopilot
+                                      mode for Performance Advisor is enabled. The
+                                      default is false.
+                                    type: boolean
+                                  compute:
+                                    description: Collection of settings that configure
+                                      how a cluster might scale its cluster tier and
+                                      whether the cluster can scale down.
+                                    properties:
+                                      enabled:
+                                        description: Flag that indicates whether cluster
+                                          tier auto-scaling is enabled. The default
+                                          is false.
+                                        type: boolean
+                                      maxInstanceSize:
+                                        description: 'Maximum instance size to which
+                                          your cluster can automatically scale (such
+                                          as M40). Atlas requires this parameter if
+                                          "autoScaling.compute.enabled" : true.'
+                                        type: string
+                                      minInstanceSize:
+                                        description: 'Minimum instance size to which
+                                          your cluster can automatically scale (such
+                                          as M10). Atlas requires this parameter if
+                                          "autoScaling.compute.scaleDownEnabled" :
+                                          true.'
+                                        type: string
+                                      scaleDownEnabled:
+                                        description: 'Flag that indicates whether
+                                          the cluster tier may scale down. Atlas requires
+                                          this parameter if "autoScaling.compute.enabled"
+                                          : true.'
+                                        type: boolean
+                                    type: object
+                                  diskGBEnabled:
+                                    description: Flag that indicates whether disk
+                                      auto-scaling is enabled. The default is true.
+                                    type: boolean
+                                type: object
+                              backingProviderName:
+                                type: string
+                              electableSpecs:
+                                properties:
+                                  diskIOPS:
+                                    format: int64
+                                    type: integer
+                                  ebsVolumeType:
+                                    type: string
+                                  instanceSize:
+                                    type: string
+                                  nodeCount:
+                                    type: integer
+                                type: object
+                              priority:
+                                type: integer
+                              providerName:
+                                type: string
+                              readOnlySpecs:
+                                properties:
+                                  diskIOPS:
+                                    format: int64
+                                    type: integer
+                                  ebsVolumeType:
+                                    type: string
+                                  instanceSize:
+                                    type: string
+                                  nodeCount:
+                                    type: integer
+                                type: object
+                              regionName:
+                                type: string
+                            type: object
+                          type: array
+                        zoneName:
+                          type: string
+                      type: object
+                    type: array
+                  rootCertType:
+                    type: string
+                  stateName:
+                    type: string
+                  versionReleaseSystem:
+                    type: string
                 type: object
-              providerBackupEnabled:
-                description: Applicable only for M10+ clusters. Flag that indicates
-                  if the cluster uses Cloud Backups for backups.
-                type: boolean
-              providerSettings:
-                description: Configuration for the provisioned hosts on which MongoDB
-                  runs. The available options are specific to the cloud service provider.
+              clusterSpec:
                 properties:
                   autoScaling:
-                    description: Range of instance sizes to which your cluster can
-                      scale.
+                    description: Collection of settings that configures auto-scaling
+                      information for the cluster. If you specify the autoScaling
+                      object, you must also specify the providerSettings.autoScaling
+                      object.
                     properties:
                       autoIndexingEnabled:
                         description: Flag that indicates whether autopilot mode for
@@ -211,121 +298,269 @@ spec:
                           is enabled. The default is true.
                         type: boolean
                     type: object
-                  backingProviderName:
-                    description: 'Cloud service provider on which the host for a multi-tenant
-                      cluster is provisioned. This setting only works when "providerSetting.providerName"
-                      : "TENANT" and "providerSetting.instanceSizeName" : M2 or M5.'
+                  biConnector:
+                    description: Configuration of BI Connector for Atlas on this cluster.
+                      The MongoDB Connector for Business Intelligence for Atlas (BI
+                      Connector) is only available for M10 and larger clusters.
+                    properties:
+                      enabled:
+                        description: Flag that indicates whether or not BI Connector
+                          for Atlas is enabled on the cluster.
+                        type: boolean
+                      readPreference:
+                        description: Source from which the BI Connector for Atlas
+                          reads data. Each BI Connector for Atlas read preference
+                          contains a distinct combination of readPreference and readPreferenceTags
+                          options.
+                        type: string
+                    type: object
+                  clusterType:
+                    description: Type of the cluster that you want to create. The
+                      parameter is required if replicationSpecs are set or if Global
+                      Clusters are deployed.
                     enum:
-                    - AWS
-                    - GCP
-                    - AZURE
+                    - REPLICASET
+                    - SHARDED
+                    - GEOSHARDED
                     type: string
-                  diskIOPS:
-                    description: Disk IOPS setting for AWS storage. Set only if you
-                      selected AWS as your cloud service provider.
-                    format: int64
+                  diskSizeGB:
+                    description: Capacity, in gigabytes, of the host's root volume.
+                      Increase this number to add capacity, up to a maximum possible
+                      value of 4096 (i.e., 4 TB). This value must be a positive integer.
+                      The parameter is required if replicationSpecs are configured.
+                    maximum: 4096
+                    minimum: 0
                     type: integer
-                  diskTypeName:
-                    description: Type of disk if you selected Azure as your cloud
-                      service provider.
-                    type: string
-                  encryptEBSVolume:
-                    description: Flag that indicates whether the Amazon EBS encryption
-                      feature encrypts the host's root volume for both data at rest
-                      within the volume and for data moving between the volume and
-                      the cluster.
-                    type: boolean
-                  instanceSizeName:
-                    description: Atlas provides different cluster tiers, each with
-                      a default storage capacity and RAM size. The cluster you select
-                      is used for all the data-bearing hosts in your cluster tier.
-                    type: string
-                  providerName:
-                    description: Cloud service provider on which Atlas provisions
-                      the hosts.
+                  encryptionAtRestProvider:
+                    description: Cloud service provider that offers Encryption at
+                      Rest.
                     enum:
                     - AWS
                     - GCP
                     - AZURE
-                    - TENANT
+                    - NONE
                     type: string
-                  regionName:
-                    description: Physical location of your MongoDB cluster. The region
-                      you choose can affect network latency for clients accessing
-                      your databases.
+                  labels:
+                    description: Collection of key-value pairs that tag and categorize
+                      the cluster. Each key and value has a maximum length of 255
+                      characters.
+                    items:
+                      description: LabelSpec contains key-value pairs that tag and
+                        categorize the Cluster/DBUser
+                      properties:
+                        key:
+                          maxLength: 255
+                          type: string
+                        value:
+                          type: string
+                      required:
+                      - key
+                      - value
+                      type: object
+                    type: array
+                  mongoDBMajorVersion:
+                    description: Version of the cluster to deploy.
                     type: string
-                  volumeType:
-                    description: Disk IOPS setting for AWS storage. Set only if you
-                      selected AWS as your cloud service provider.
-                    enum:
-                    - STANDARD
-                    - PROVISIONED
+                  name:
+                    description: Name of the cluster as it appears in Atlas. After
+                      Atlas creates the cluster, you can't change its name.
+                    type: string
+                  numShards:
+                    description: Positive integer that specifies the number of shards
+                      to deploy for a sharded cluster. The parameter is required if
+                      replicationSpecs are configured
+                    maximum: 50
+                    minimum: 1
+                    type: integer
+                  paused:
+                    description: Flag that indicates whether the cluster should be
+                      paused.
+                    type: boolean
+                  pitEnabled:
+                    description: Flag that indicates the cluster uses continuous cloud
+                      backups.
+                    type: boolean
+                  providerBackupEnabled:
+                    description: Applicable only for M10+ clusters. Flag that indicates
+                      if the cluster uses Cloud Backups for backups.
+                    type: boolean
+                  providerSettings:
+                    description: Configuration for the provisioned hosts on which
+                      MongoDB runs. The available options are specific to the cloud
+                      service provider.
+                    properties:
+                      autoScaling:
+                        description: Range of instance sizes to which your cluster
+                          can scale.
+                        properties:
+                          autoIndexingEnabled:
+                            description: Flag that indicates whether autopilot mode
+                              for Performance Advisor is enabled. The default is false.
+                            type: boolean
+                          compute:
+                            description: Collection of settings that configure how
+                              a cluster might scale its cluster tier and whether the
+                              cluster can scale down.
+                            properties:
+                              enabled:
+                                description: Flag that indicates whether cluster tier
+                                  auto-scaling is enabled. The default is false.
+                                type: boolean
+                              maxInstanceSize:
+                                description: 'Maximum instance size to which your
+                                  cluster can automatically scale (such as M40). Atlas
+                                  requires this parameter if "autoScaling.compute.enabled"
+                                  : true.'
+                                type: string
+                              minInstanceSize:
+                                description: 'Minimum instance size to which your
+                                  cluster can automatically scale (such as M10). Atlas
+                                  requires this parameter if "autoScaling.compute.scaleDownEnabled"
+                                  : true.'
+                                type: string
+                              scaleDownEnabled:
+                                description: 'Flag that indicates whether the cluster
+                                  tier may scale down. Atlas requires this parameter
+                                  if "autoScaling.compute.enabled" : true.'
+                                type: boolean
+                            type: object
+                          diskGBEnabled:
+                            description: Flag that indicates whether disk auto-scaling
+                              is enabled. The default is true.
+                            type: boolean
+                        type: object
+                      backingProviderName:
+                        description: 'Cloud service provider on which the host for
+                          a multi-tenant cluster is provisioned. This setting only
+                          works when "providerSetting.providerName" : "TENANT" and
+                          "providerSetting.instanceSizeName" : M2 or M5.'
+                        enum:
+                        - AWS
+                        - GCP
+                        - AZURE
+                        type: string
+                      diskIOPS:
+                        description: Disk IOPS setting for AWS storage. Set only if
+                          you selected AWS as your cloud service provider.
+                        format: int64
+                        type: integer
+                      diskTypeName:
+                        description: Type of disk if you selected Azure as your cloud
+                          service provider.
+                        type: string
+                      encryptEBSVolume:
+                        description: Flag that indicates whether the Amazon EBS encryption
+                          feature encrypts the host's root volume for both data at
+                          rest within the volume and for data moving between the volume
+                          and the cluster.
+                        type: boolean
+                      instanceSizeName:
+                        description: Atlas provides different cluster tiers, each
+                          with a default storage capacity and RAM size. The cluster
+                          you select is used for all the data-bearing hosts in your
+                          cluster tier.
+                        type: string
+                      providerName:
+                        description: Cloud service provider on which Atlas provisions
+                          the hosts.
+                        enum:
+                        - AWS
+                        - GCP
+                        - AZURE
+                        - TENANT
+                        type: string
+                      regionName:
+                        description: Physical location of your MongoDB cluster. The
+                          region you choose can affect network latency for clients
+                          accessing your databases.
+                        type: string
+                      volumeType:
+                        description: Disk IOPS setting for AWS storage. Set only if
+                          you selected AWS as your cloud service provider.
+                        enum:
+                        - STANDARD
+                        - PROVISIONED
+                        type: string
+                    required:
+                    - instanceSizeName
+                    - providerName
+                    type: object
+                  replicationSpecs:
+                    description: Configuration for cluster regions.
+                    items:
+                      description: ReplicationSpec represents a configuration for
+                        cluster regions
+                      properties:
+                        numShards:
+                          description: Number of shards to deploy in each specified
+                            zone. The default value is 1.
+                          format: int64
+                          type: integer
+                        regionsConfig:
+                          additionalProperties:
+                            description: RegionsConfig describes the region’s priority
+                              in elections and the number and type of MongoDB nodes
+                              Atlas deploys to the region.
+                            properties:
+                              analyticsNodes:
+                                description: The number of analytics nodes for Atlas
+                                  to deploy to the region. Analytics nodes are useful
+                                  for handling analytic data such as reporting queries
+                                  from BI Connector for Atlas. Analytics nodes are
+                                  read-only, and can never become the primary. If
+                                  you do not specify this option, no analytics nodes
+                                  are deployed to the region.
+                                format: int64
+                                type: integer
+                              electableNodes:
+                                description: Number of electable nodes for Atlas to
+                                  deploy to the region. Electable nodes can become
+                                  the primary and can facilitate local reads.
+                                format: int64
+                                type: integer
+                              priority:
+                                description: Election priority of the region. For
+                                  regions with only replicationSpecs[n].regionsConfig.<region>.readOnlyNodes,
+                                  set this value to 0.
+                                format: int64
+                                type: integer
+                              readOnlyNodes:
+                                description: Number of read-only nodes for Atlas to
+                                  deploy to the region. Read-only nodes can never
+                                  become the primary, but can facilitate local-reads.
+                                format: int64
+                                type: integer
+                            type: object
+                          description: Configuration for a region. Each regionsConfig
+                            object describes the region's priority in elections and
+                            the number and type of MongoDB nodes that Atlas deploys
+                            to the region.
+                          type: object
+                        zoneName:
+                          description: Name for the zone in a Global Cluster. Don't
+                            provide this value if clusterType is not GEOSHARDED.
+                          type: string
+                      type: object
+                    type: array
+                required:
+                - name
+                - providerSettings
+                type: object
+              projectRef:
+                description: Project is a reference to AtlasProject resource the cluster
+                  belongs to
+                properties:
+                  name:
+                    description: Name is the name of the Kubernetes Resource
+                    type: string
+                  namespace:
+                    description: Namespace is the namespace of the Kubernetes Resource
                     type: string
                 required:
-                - instanceSizeName
-                - providerName
+                - name
                 type: object
-              replicationSpecs:
-                description: Configuration for cluster regions.
-                items:
-                  description: ReplicationSpec represents a configuration for cluster
-                    regions
-                  properties:
-                    numShards:
-                      description: Number of shards to deploy in each specified zone.
-                        The default value is 1.
-                      format: int64
-                      type: integer
-                    regionsConfig:
-                      additionalProperties:
-                        description: RegionsConfig describes the region’s priority
-                          in elections and the number and type of MongoDB nodes Atlas
-                          deploys to the region.
-                        properties:
-                          analyticsNodes:
-                            description: The number of analytics nodes for Atlas to
-                              deploy to the region. Analytics nodes are useful for
-                              handling analytic data such as reporting queries from
-                              BI Connector for Atlas. Analytics nodes are read-only,
-                              and can never become the primary. If you do not specify
-                              this option, no analytics nodes are deployed to the
-                              region.
-                            format: int64
-                            type: integer
-                          electableNodes:
-                            description: Number of electable nodes for Atlas to deploy
-                              to the region. Electable nodes can become the primary
-                              and can facilitate local reads.
-                            format: int64
-                            type: integer
-                          priority:
-                            description: Election priority of the region. For regions
-                              with only replicationSpecs[n].regionsConfig.<region>.readOnlyNodes,
-                              set this value to 0.
-                            format: int64
-                            type: integer
-                          readOnlyNodes:
-                            description: Number of read-only nodes for Atlas to deploy
-                              to the region. Read-only nodes can never become the
-                              primary, but can facilitate local-reads.
-                            format: int64
-                            type: integer
-                        type: object
-                      description: Configuration for a region. Each regionsConfig
-                        object describes the region's priority in elections and the
-                        number and type of MongoDB nodes that Atlas deploys to the
-                        region.
-                      type: object
-                    zoneName:
-                      description: Name for the zone in a Global Cluster. Don't provide
-                        this value if clusterType is not GEOSHARDED.
-                      type: string
-                  type: object
-                type: array
             required:
-            - name
             - projectRef
-            - providerSettings
             type: object
           status:
             description: AtlasClusterStatus defines the observed state of AtlasCluster.
@@ -396,6 +631,10 @@ spec:
                             properties:
                               endpointId:
                                 description: Unique identifier of the private endpoint.
+                                type: string
+                              ip:
+                                description: Private IP address of the private endpoint
+                                  network interface you created in your Azure VNet.
                                 type: string
                               providerName:
                                 description: Cloud provider to which you deployed


### PR DESCRIPTION
### All Submissions:

This PR moves the values from spec out one line into `.clusterSpec`. It also adds a new field `.advancedClusterSpec` which at the moment is just a direct pass through.

* [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
