### PR TITLE
Kubernetes Enterprise Operator Release 1.16.1

### DIFF
--- a/charts/enterprise-operator/Chart.yaml
+++ b/charts/enterprise-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: enterprise-operator
 description: MongoDB Kubernetes Enterprise Operator
-version: 1.16.0
+version: 1.16.1
 kubeVersion: '>=1.16-0'
 type: application
 keywords:

--- a/charts/enterprise-operator/crds/mongodb.com_mongodb.yaml
+++ b/charts/enterprise-operator/crds/mongodb.com_mongodb.yaml
@@ -602,8 +602,9 @@ spec:
                     type: object
                 type: object
               service:
-                description: this is an optional service, it will get the name "<rsName>-service"
-                  in case not provided
+                description: DEPRECATED please use `spec.statefulSet.spec.serviceName`
+                  to provide a custom service name. this is an optional service, it
+                  will get the name "<rsName>-service" in case not provided
                 type: string
               shard:
                 properties:
@@ -680,6 +681,16 @@ spec:
                   podTemplate:
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
+                type: object
+              statefulSet:
+                description: StatefulSetConfiguration holds the optional custom StatefulSet
+                  that should be merged into the operator created one.
+                properties:
+                  spec:
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                required:
+                - spec
                 type: object
               type:
                 enum:

--- a/charts/enterprise-operator/templates/_helpers.tpl
+++ b/charts/enterprise-operator/templates/_helpers.tpl
@@ -1,0 +1,13 @@
+{{/* vim: set filetype=mustache: */}}
+
+{{/*
+    Define the namespace in which the operator deployment will be running.
+    This can be used to override the installation of the operator in the same namespace as the helm release
+*/}}
+{{- define "mongodb-enterprise-operator.namespace" -}}
+{{- if .Values.operator.namespace -}}
+{{- .Values.operator.namespace -}}
+{{- else -}}
+{{- .Release.Namespace -}}
+{{- end -}}
+{{- end -}}

--- a/charts/enterprise-operator/templates/database-roles.yaml
+++ b/charts/enterprise-operator/templates/database-roles.yaml
@@ -1,4 +1,4 @@
-{{- $watchNamespace := list .Release.Namespace }}
+{{- $watchNamespace := include "mongodb-enterprise-operator.namespace" . | list }}
 {{- if .Values.operator.watchNamespace }}
 {{- $watchNamespace = regexSplit "," .Values.operator.watchNamespace -1 }}
 {{- end }}
@@ -8,7 +8,7 @@
 
 {{- $namespaceBlock := printf "namespace: %s" $namespace }}
 {{- if eq $namespace "*" }}
-{{- $namespaceBlock = printf "namespace: %s" $.Release.Namespace }}
+{{- $namespaceBlock = include "mongodb-enterprise-operator.namespace" $ | printf "namespace: %s"  }}
 {{- end }}
 ---
 apiVersion: v1

--- a/charts/enterprise-operator/templates/operator-roles.yaml
+++ b/charts/enterprise-operator/templates/operator-roles.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ .Values.operator.name }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "mongodb-enterprise-operator.namespace" . }}
 {{- if .Values.registry.imagePullSecrets}}
 imagePullSecrets:
 - name: {{ .Values.registry.imagePullSecrets }}
@@ -12,10 +12,10 @@ imagePullSecrets:
 
 {{- end }}
 
-{{- $watchNamespace := list .Release.Namespace }}
+{{- $watchNamespace := include "mongodb-enterprise-operator.namespace" . | list }}
 {{- if .Values.operator.watchNamespace }}
 {{- $watchNamespace = regexSplit "," .Values.operator.watchNamespace -1 }}
-{{- $watchNamespace = concat $watchNamespace (list .Release.Namespace) }}
+{{- $watchNamespace = concat $watchNamespace (include "mongodb-enterprise-operator.namespace" . | list) }}
 {{- end }}
 
 {{- $roleScope := "Role" -}}
@@ -29,7 +29,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ .Values.operator.name }}
 {{- if eq $roleScope "Role" }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "mongodb-enterprise-operator.namespace" . }}
 {{- end }}
 rules:
 - apiGroups:
@@ -112,7 +112,7 @@ rules:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ .Values.operator.name }}-{{ .Release.Namespace }}-webhook-binding
+  name: {{ .Values.operator.name }}-{{ include "mongodb-enterprise-operator.namespace" . }}-webhook-binding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -120,7 +120,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ .Values.operator.name }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "mongodb-enterprise-operator.namespace" . }}
 
 {{- range $idx, $namespace := $watchNamespace }}
 
@@ -146,5 +146,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ $.Values.operator.name }}
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ include "mongodb-enterprise-operator.namespace" $ }}
 {{- end }}

--- a/charts/enterprise-operator/templates/operator.yaml
+++ b/charts/enterprise-operator/templates/operator.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Values.operator.name }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "mongodb-enterprise-operator.namespace" . }}
 spec:
   replicas: 1
   selector:

--- a/charts/enterprise-operator/templates/secret-config.yaml
+++ b/charts/enterprise-operator/templates/secret-config.yaml
@@ -5,7 +5,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: secret-configuration
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "mongodb-enterprise-operator.namespace" . }}
 data:
  {{- if .Values.operator.vaultSecretBackend.tlsSecretRef }}
   VAULT_SERVER_ADDRESS: https://vault.vault.svc.cluster.local:8200

--- a/charts/enterprise-operator/values-openshift.yaml
+++ b/charts/enterprise-operator/values-openshift.yaml
@@ -18,7 +18,7 @@ operator:
   deployment_name: mongodb-enterprise-operator
 
   # Version of mongodb-enterprise-operator
-  version: 1.16.0
+  version: 1.16.1
 
   # The Custom Resources that will be watched by the Operator. Needs to be changed if only some of the CRDs are installed
   watchedResources:

--- a/charts/enterprise-operator/values.yaml
+++ b/charts/enterprise-operator/values.yaml
@@ -18,7 +18,7 @@ operator:
   deployment_name: mongodb-enterprise-operator
 
   # Version of mongodb-enterprise-operator
-  version: 1.16.0
+  version: 1.16.1
 
   # The Custom Resources that will be watched by the Operator. Needs to be changed if only some of the CRDs are installed
   watchedResources:


### PR DESCRIPTION
## Kubernetes Enterprise Operator Release 1.16.1


This release patch has been created and it should be reviewed now.


You can add new commits to this patch if needed. After changes have
been reviewed, merge this PR for PCT to continue the release process.