### PR TITLE
configurable resources for enterprise-operator with current defaults …

### DIFF
--- a/charts/enterprise-operator/templates/operator.yaml
+++ b/charts/enterprise-operator/templates/operator.yaml
@@ -62,11 +62,11 @@ spec:
         {{- end }}
         resources:
           limits:
-            cpu: 1100m
-            memory: 1Gi
+            cpu: {{ .Values.operator.resources.limits.cpu }}
+            memory: {{ .Values.operator.resources.limits.memory }}
           requests:
-            cpu: 500m
-            memory: 200Mi
+            cpu: {{ .Values.operator.resources.requests.cpu }}
+            memory: {{ .Values.operator.resources.requests.memory }}
         env:
         - name: OPERATOR_ENV
           value: {{ .Values.operator.env }}

--- a/charts/enterprise-operator/values-openshift.yaml
+++ b/charts/enterprise-operator/values-openshift.yaml
@@ -32,6 +32,14 @@ operator:
 
   affinity: {}
 
+  resources:
+    requests:
+      cpu: 500m
+      memory: 200Mi
+    limits:
+      cpu: 1100m
+      memory: 1Gi
+
 ## Database
 database:
   name: enterprise-database

--- a/charts/enterprise-operator/values.yaml
+++ b/charts/enterprise-operator/values.yaml
@@ -32,6 +32,14 @@ operator:
 
   affinity: {}
 
+  resources:
+    requests:
+      cpu: 500m
+      memory: 200Mi
+    limits:
+      cpu: 1100m
+      memory: 1Gi
+
   # Create operator-service account
   createOperatorServiceAccount: true
 


### PR DESCRIPTION
enterprise operator resources should be configurable by helm values. The old and current defaults are now in the values files, an can be overridden, if wanted.

### All Submissions:

* [x] Have you opened an Issue before filing this PR? - MongoDB Support
* [x] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
