### PR TITLE
Kubernetes Enterprise Operator Release 1.16.2

### DIFF
--- a/charts/enterprise-operator/Chart.yaml
+++ b/charts/enterprise-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: enterprise-operator
 description: MongoDB Kubernetes Enterprise Operator
-version: 1.16.1
+version: 1.16.2
 kubeVersion: '>=1.16-0'
 type: application
 keywords:

--- a/charts/enterprise-operator/crds/mongodb.com_mongodb.yaml
+++ b/charts/enterprise-operator/crds/mongodb.com_mongodb.yaml
@@ -112,9 +112,6 @@ spec:
                 x-kubernetes-preserve-unknown-fields: true
               configSrvPodSpec:
                 properties:
-                  nodeAffinity:
-                    type: object
-                    x-kubernetes-preserve-unknown-fields: true
                   persistence:
                     properties:
                       multiple:
@@ -161,11 +158,6 @@ spec:
                             type: string
                         type: object
                     type: object
-                  podAffinity:
-                    type: object
-                    x-kubernetes-preserve-unknown-fields: true
-                  podAntiAffinityTopologyKey:
-                    type: string
                   podTemplate:
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
@@ -226,9 +218,6 @@ spec:
                 type: integer
               mongosPodSpec:
                 properties:
-                  nodeAffinity:
-                    type: object
-                    x-kubernetes-preserve-unknown-fields: true
                   persistence:
                     properties:
                       multiple:
@@ -275,11 +264,6 @@ spec:
                             type: string
                         type: object
                     type: object
-                  podAffinity:
-                    type: object
-                    x-kubernetes-preserve-unknown-fields: true
-                  podAntiAffinityTopologyKey:
-                    type: string
                   podTemplate:
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
@@ -296,9 +280,6 @@ spec:
                 type: boolean
               podSpec:
                 properties:
-                  nodeAffinity:
-                    type: object
-                    x-kubernetes-preserve-unknown-fields: true
                   persistence:
                     properties:
                       multiple:
@@ -345,11 +326,6 @@ spec:
                             type: string
                         type: object
                     type: object
-                  podAffinity:
-                    type: object
-                    x-kubernetes-preserve-unknown-fields: true
-                  podAntiAffinityTopologyKey:
-                    type: string
                   podTemplate:
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
@@ -624,9 +600,6 @@ spec:
                 type: integer
               shardPodSpec:
                 properties:
-                  nodeAffinity:
-                    type: object
-                    x-kubernetes-preserve-unknown-fields: true
                   persistence:
                     properties:
                       multiple:
@@ -673,11 +646,6 @@ spec:
                             type: string
                         type: object
                     type: object
-                  podAffinity:
-                    type: object
-                    x-kubernetes-preserve-unknown-fields: true
-                  podAntiAffinityTopologyKey:
-                    type: string
                   podTemplate:
                     type: object
                     x-kubernetes-preserve-unknown-fields: true

--- a/charts/enterprise-operator/crds/mongodb.com_opsmanagers.yaml
+++ b/charts/enterprise-operator/crds/mongodb.com_opsmanagers.yaml
@@ -184,9 +184,6 @@ spec:
                     type: object
                   podSpec:
                     properties:
-                      nodeAffinity:
-                        type: object
-                        x-kubernetes-preserve-unknown-fields: true
                       persistence:
                         properties:
                           multiple:
@@ -233,11 +230,6 @@ spec:
                                 type: string
                             type: object
                         type: object
-                      podAffinity:
-                        type: object
-                        x-kubernetes-preserve-unknown-fields: true
-                      podAntiAffinityTopologyKey:
-                        type: string
                       podTemplate:
                         type: object
                         x-kubernetes-preserve-unknown-fields: true

--- a/charts/enterprise-operator/values-openshift.yaml
+++ b/charts/enterprise-operator/values-openshift.yaml
@@ -18,7 +18,7 @@ operator:
   deployment_name: mongodb-enterprise-operator
 
   # Version of mongodb-enterprise-operator
-  version: 1.16.1
+  version: 1.16.2
 
   # The Custom Resources that will be watched by the Operator. Needs to be changed if only some of the CRDs are installed
   watchedResources:

--- a/charts/enterprise-operator/values.yaml
+++ b/charts/enterprise-operator/values.yaml
@@ -18,7 +18,7 @@ operator:
   deployment_name: mongodb-enterprise-operator
 
   # Version of mongodb-enterprise-operator
-  version: 1.16.1
+  version: 1.16.2
 
   # The Custom Resources that will be watched by the Operator. Needs to be changed if only some of the CRDs are installed
   watchedResources:


### PR DESCRIPTION
## Kubernetes Enterprise Operator Release 1.16.2


This release patch has been created and it should be reviewed now.


You can add new commits to this patch if needed. After changes have
been reviewed, merge this PR for PCT to continue the release process.