### PR TITLE
Kubernetes Enterprise Operator Release 1.16.3

### DIFF
--- a/charts/enterprise-operator/Chart.yaml
+++ b/charts/enterprise-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: enterprise-operator
 description: MongoDB Kubernetes Enterprise Operator
-version: 1.16.2
+version: 1.16.3
 kubeVersion: '>=1.16-0'
 type: application
 keywords:

--- a/charts/enterprise-operator/crds/mongodb.com_mongodb.yaml
+++ b/charts/enterprise-operator/crds/mongodb.com_mongodb.yaml
@@ -464,11 +464,15 @@ spec:
                             items:
                               type: string
                             type: array
+                          timeoutMS:
+                            type: integer
                           transportSecurity:
                             enum:
                             - tls
                             - none
                             type: string
+                          userCacheInvalidationInterval:
+                            type: integer
                           userToDNMapping:
                             type: string
                           validateLDAPServerConfig:

--- a/charts/enterprise-operator/crds/mongodb.com_mongodbmulti.yaml
+++ b/charts/enterprise-operator/crds/mongodb.com_mongodbmulti.yaml
@@ -264,11 +264,15 @@ spec:
                             items:
                               type: string
                             type: array
+                          timeoutMS:
+                            type: integer
                           transportSecurity:
                             enum:
                             - tls
                             - none
                             type: string
+                          userCacheInvalidationInterval:
+                            type: integer
                           userToDNMapping:
                             type: string
                           validateLDAPServerConfig:

--- a/charts/enterprise-operator/crds/mongodb.com_opsmanagers.yaml
+++ b/charts/enterprise-operator/crds/mongodb.com_opsmanagers.yaml
@@ -377,11 +377,15 @@ spec:
                                 items:
                                   type: string
                                 type: array
+                              timeoutMS:
+                                type: integer
                               transportSecurity:
                                 enum:
                                 - tls
                                 - none
                                 type: string
+                              userCacheInvalidationInterval:
+                                type: integer
                               userToDNMapping:
                                 type: string
                               validateLDAPServerConfig:

--- a/charts/enterprise-operator/templates/operator-roles.yaml
+++ b/charts/enterprise-operator/templates/operator-roles.yaml
@@ -15,7 +15,7 @@ imagePullSecrets:
 {{- $watchNamespace := include "mongodb-enterprise-operator.namespace" . | list }}
 {{- if .Values.operator.watchNamespace }}
 {{- $watchNamespace = regexSplit "," .Values.operator.watchNamespace -1 }}
-{{- $watchNamespace = concat $watchNamespace (include "mongodb-enterprise-operator.namespace" . | list) }}
+{{- $watchNamespace = concat $watchNamespace (include "mongodb-enterprise-operator.namespace" . | list) | uniq }}
 {{- end }}
 
 {{- $roleScope := "Role" -}}

--- a/charts/enterprise-operator/values-openshift.yaml
+++ b/charts/enterprise-operator/values-openshift.yaml
@@ -18,7 +18,7 @@ operator:
   deployment_name: mongodb-enterprise-operator
 
   # Version of mongodb-enterprise-operator
-  version: 1.16.2
+  version: 1.16.3
 
   # The Custom Resources that will be watched by the Operator. Needs to be changed if only some of the CRDs are installed
   watchedResources:
@@ -39,7 +39,7 @@ database:
 
 initDatabase:
   name: mongodb-enterprise-init-database
-  version: 1.0.9
+  version: 1.0.10
 
 ## Ops Manager
 opsManager:
@@ -51,7 +51,7 @@ initOpsManager:
 
 initAppDb:
   name: mongodb-enterprise-init-appdb
-  version: 1.0.9
+  version: 1.0.10
 
 agent:
   name: mongodb-agent

--- a/charts/enterprise-operator/values.yaml
+++ b/charts/enterprise-operator/values.yaml
@@ -18,7 +18,7 @@ operator:
   deployment_name: mongodb-enterprise-operator
 
   # Version of mongodb-enterprise-operator
-  version: 1.16.2
+  version: 1.16.3
 
   # The Custom Resources that will be watched by the Operator. Needs to be changed if only some of the CRDs are installed
   watchedResources:
@@ -47,7 +47,7 @@ database:
 
 initDatabase:
   name: mongodb-enterprise-init-database
-  version: 1.0.9
+  version: 1.0.10
 
 ## Ops Manager
 opsManager:
@@ -60,7 +60,7 @@ initOpsManager:
 ## Application Database
 initAppDb:
   name: mongodb-enterprise-init-appdb
-  version: 1.0.9
+  version: 1.0.10
 
 agent:
   name: mongodb-agent


### PR DESCRIPTION
## Kubernetes Enterprise Operator Release 1.16.3


This release patch has been created and it should be reviewed now.


You can add new commits to this patch if needed. After changes have
been reviewed, merge this PR for PCT to continue the release process.