### PR TITLE
Kubernetes Enterprise Operator Release 1.16.4

### DIFF
--- a/charts/enterprise-operator/Chart.yaml
+++ b/charts/enterprise-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: enterprise-operator
 description: MongoDB Kubernetes Enterprise Operator
-version: 1.16.3
+version: 1.16.4
 kubeVersion: '>=1.16-0'
 type: application
 keywords:

--- a/charts/enterprise-operator/values-openshift.yaml
+++ b/charts/enterprise-operator/values-openshift.yaml
@@ -18,7 +18,7 @@ operator:
   deployment_name: mongodb-enterprise-operator
 
   # Version of mongodb-enterprise-operator
-  version: 1.16.3
+  version: 1.16.4
 
   # The Custom Resources that will be watched by the Operator. Needs to be changed if only some of the CRDs are installed
   watchedResources:
@@ -39,7 +39,7 @@ database:
 
 initDatabase:
   name: mongodb-enterprise-init-database
-  version: 1.0.10
+  version: 1.0.11
 
 ## Ops Manager
 opsManager:
@@ -47,11 +47,11 @@ opsManager:
 
 initOpsManager:
   name: mongodb-enterprise-init-ops-manager
-  version: 1.0.7
+  version: 1.0.8
 
 initAppDb:
   name: mongodb-enterprise-init-appdb
-  version: 1.0.10
+  version: 1.0.11
 
 agent:
   name: mongodb-agent

--- a/charts/enterprise-operator/values.yaml
+++ b/charts/enterprise-operator/values.yaml
@@ -18,7 +18,7 @@ operator:
   deployment_name: mongodb-enterprise-operator
 
   # Version of mongodb-enterprise-operator
-  version: 1.16.3
+  version: 1.16.4
 
   # The Custom Resources that will be watched by the Operator. Needs to be changed if only some of the CRDs are installed
   watchedResources:
@@ -47,7 +47,7 @@ database:
 
 initDatabase:
   name: mongodb-enterprise-init-database
-  version: 1.0.10
+  version: 1.0.11
 
 ## Ops Manager
 opsManager:
@@ -55,12 +55,12 @@ opsManager:
 
 initOpsManager:
   name: mongodb-enterprise-init-ops-manager
-  version: 1.0.7
+  version: 1.0.8
 
 ## Application Database
 initAppDb:
   name: mongodb-enterprise-init-appdb
-  version: 1.0.10
+  version: 1.0.11
 
 agent:
   name: mongodb-agent


### PR DESCRIPTION
## Kubernetes Enterprise Operator Release 1.16.4


This release patch has been created and it should be reviewed now.


You can add new commits to this patch if needed. After changes have
been reviewed, merge this PR for PCT to continue the release process.