### PR TITLE
Kubernetes Enterprise Operator Release 1.17.0

### DIFF
--- a/charts/enterprise-operator/Chart.yaml
+++ b/charts/enterprise-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: enterprise-operator
 description: MongoDB Kubernetes Enterprise Operator
-version: 1.16.4
+version: 1.17.0
 kubeVersion: '>=1.16-0'
 type: application
 keywords:

--- a/charts/enterprise-operator/crds/mongodb.com_opsmanagers.yaml
+++ b/charts/enterprise-operator/crds/mongodb.com_opsmanagers.yaml
@@ -659,6 +659,8 @@ spec:
                           type: string
                         s3BucketName:
                           type: string
+                        s3RegionOverride:
+                          type: string
                         s3SecretRef:
                           properties:
                             name:
@@ -709,6 +711,8 @@ spec:
                         s3BucketEndpoint:
                           type: string
                         s3BucketName:
+                          type: string
+                        s3RegionOverride:
                           type: string
                         s3SecretRef:
                           properties:

--- a/charts/enterprise-operator/templates/operator.yaml
+++ b/charts/enterprise-operator/templates/operator.yaml
@@ -123,7 +123,10 @@ spec:
           value: {{ .Values.mongodb.name }}
         - name: MONGODB_REPO_URL
           value: {{ .Values.mongodb.repo }}
-
+{{- if eq .Values.multiCluster.performFailOver true }}
+        - name: PERFORM_FAILOVER
+          value: 'true'
+{{- end }}
 {{- if .Values.registry.imagePullSecrets }}
         - name: IMAGE_PULL_SECRETS
           value: {{ .Values.registry.imagePullSecrets }}

--- a/charts/enterprise-operator/values-openshift.yaml
+++ b/charts/enterprise-operator/values-openshift.yaml
@@ -18,7 +18,7 @@ operator:
   deployment_name: mongodb-enterprise-operator
 
   # Version of mongodb-enterprise-operator
-  version: 1.16.4
+  version: 1.17.0
 
   # The Custom Resources that will be watched by the Operator. Needs to be changed if only some of the CRDs are installed
   watchedResources:
@@ -39,7 +39,7 @@ database:
 
 initDatabase:
   name: mongodb-enterprise-init-database
-  version: 1.0.11
+  version: 1.0.12
 
 ## Ops Manager
 opsManager:
@@ -47,11 +47,11 @@ opsManager:
 
 initOpsManager:
   name: mongodb-enterprise-init-ops-manager
-  version: 1.0.8
+  version: 1.0.9
 
 initAppDb:
   name: mongodb-enterprise-init-appdb
-  version: 1.0.11
+  version: 1.0.12
 
 agent:
   name: mongodb-agent

--- a/charts/enterprise-operator/values.yaml
+++ b/charts/enterprise-operator/values.yaml
@@ -18,7 +18,7 @@ operator:
   deployment_name: mongodb-enterprise-operator
 
   # Version of mongodb-enterprise-operator
-  version: 1.16.4
+  version: 1.17.0
 
   # The Custom Resources that will be watched by the Operator. Needs to be changed if only some of the CRDs are installed
   watchedResources:
@@ -47,7 +47,7 @@ database:
 
 initDatabase:
   name: mongodb-enterprise-init-database
-  version: 1.0.11
+  version: 1.0.12
 
 ## Ops Manager
 opsManager:
@@ -55,12 +55,12 @@ opsManager:
 
 initOpsManager:
   name: mongodb-enterprise-init-ops-manager
-  version: 1.0.8
+  version: 1.0.9
 
 ## Application Database
 initAppDb:
   name: mongodb-enterprise-init-appdb
-  version: 1.0.11
+  version: 1.0.12
 
 agent:
   name: mongodb-agent
@@ -89,7 +89,7 @@ registry:
 multiCluster:
   clusters: []
   kubeConfigSecretName: mongodb-enterprise-operator-multi-cluster-kubeconfig
-
+  performFailOver: true
 
 # Set this to false to disable subresource utilization
 # It might be required on some versions of Openshift


### PR DESCRIPTION
## Kubernetes Enterprise Operator Release 1.17.0


This release patch has been created and it should be reviewed now.


You can add new commits to this patch if needed. After changes have
been reviewed, merge this PR for PCT to continue the release process.