### PR TITLE
Kubernetes Enterprise Operator Release 1.17.1

### DIFF
--- a/charts/enterprise-operator/Chart.yaml
+++ b/charts/enterprise-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: enterprise-operator
 description: MongoDB Kubernetes Enterprise Operator
-version: 1.17.0
+version: 1.17.1
 kubeVersion: '>=1.16-0'
 type: application
 keywords:

--- a/charts/enterprise-operator/templates/operator.yaml
+++ b/charts/enterprise-operator/templates/operator.yaml
@@ -40,8 +40,8 @@ spec:
       - name: {{ .Values.registry.imagePullSecrets }}
 {{- end }}
       containers:
-      - name: {{ .Values.operator.deployment_name }}
-        image: {{ .Values.registry.operator }}/{{ .Values.operator.operator_image_name }}:{{ .Values.operator.version }}{{ .Values.build }}
+      - name: {{ .Values.operator.name }}
+        image: "{{ .Values.registry.operator }}/{{ .Values.operator.operator_image_name }}:{{ .Values.operator.version }}{{ .Values.build }}"
         imagePullPolicy: {{ .Values.registry.pullPolicy }}
         {{- if .Values.operator.watchedResources }}
         args:
@@ -92,34 +92,46 @@ spec:
         - name: MANAGED_SECURITY_CONTEXT
           value: 'true'
 {{- end }}
+{{- $mongodbEnterpriseDatabaseImageEnv := "MONGODB_ENTERPRISE_DATABASE_IMAGE" -}}
+{{- $initDatabaseImageRepositoryEnv := "INIT_DATABASE_IMAGE_REPOSITORY" -}}
+{{- $opsManagerImageRepositoryEnv := "OPS_MANAGER_IMAGE_REPOSITORY" -}}
+{{- $initOpsManagerImageRepositoryEnv := "INIT_OPS_MANAGER_IMAGE_REPOSITORY" -}}
+{{- $initAppDbImageRepositoryEnv := "INIT_APPDB_IMAGE_REPOSITORY" -}}
+{{- $agentImageEnv := "AGENT_IMAGE" -}}
+{{- $mongodbImageEnv := "MONGODB_IMAGE" -}}
+{{- $initDatabaseVersion := print .Values.initDatabase.version (.Values.build | default "") -}}
+{{- $databaseVersion := print .Values.database.version (.Values.build | default "") -}}
+{{- $initOpsManagerVersion := print .Values.initOpsManager.version (.Values.build | default "") -}}
+{{- $initAppDbVersion := print .Values.initAppDb.version (.Values.build | default "") -}}
+{{- $agentVersion := .Values.agent.version }}
         - name: IMAGE_PULL_POLICY
           value: {{ .Values.registry.pullPolicy }}
         # Database
-        - name: MONGODB_ENTERPRISE_DATABASE_IMAGE
+        - name: {{ $mongodbEnterpriseDatabaseImageEnv }}
           value: {{ .Values.registry.database }}/{{ .Values.database.name }}
-        - name: INIT_DATABASE_IMAGE_REPOSITORY
+        - name: {{ $initDatabaseImageRepositoryEnv }}
           value: {{ .Values.registry.initDatabase }}/{{ .Values.initDatabase.name }}
         - name: INIT_DATABASE_VERSION
-          value: {{ .Values.initDatabase.version }}{{ .Values.build }}
+          value: {{ $initDatabaseVersion }}
         - name: DATABASE_VERSION
-          value: {{ .Values.database.version }}{{ .Values.build }}
+          value: {{ $databaseVersion }}
         # Ops Manager
-        - name: OPS_MANAGER_IMAGE_REPOSITORY
+        - name: {{ $opsManagerImageRepositoryEnv }}
           value: {{ .Values.registry.opsManager }}/{{ .Values.opsManager.name }}
-        - name: INIT_OPS_MANAGER_IMAGE_REPOSITORY
+        - name: {{ $initOpsManagerImageRepositoryEnv }}
           value: {{ .Values.registry.initOpsManager }}/{{ .Values.initOpsManager.name }}
         - name: INIT_OPS_MANAGER_VERSION
-          value: {{ .Values.initOpsManager.version }}{{ .Values.build }}
+          value: {{ $initOpsManagerVersion }}
         # AppDB
-        - name: INIT_APPDB_IMAGE_REPOSITORY
+        - name: {{ $initAppDbImageRepositoryEnv }}
           value: {{ .Values.registry.initAppDb }}/{{ .Values.initAppDb.name }}
         - name: INIT_APPDB_VERSION
-          value: {{ .Values.initAppDb.version }}{{ .Values.build }}
+          value: {{ $initAppDbVersion }}
         - name: OPS_MANAGER_IMAGE_PULL_POLICY
           value: {{ .Values.registry.pullPolicy }}
-        - name: AGENT_IMAGE
-          value: {{ .Values.registry.agent }}/{{ .Values.agent.name }}:{{ .Values.agent.version }}
-        - name: MONGODB_IMAGE
+        - name: {{ $agentImageEnv }}
+          value: "{{ .Values.registry.agent }}/{{ .Values.agent.name }}:{{ $agentVersion }}"
+        - name: {{ $mongodbImageEnv }}
           value: {{ .Values.mongodb.name }}
         - name: MONGODB_REPO_URL
           value: {{ .Values.mongodb.repo }}
@@ -130,6 +142,28 @@ spec:
 {{- if .Values.registry.imagePullSecrets }}
         - name: IMAGE_PULL_SECRETS
           value: {{ .Values.registry.imagePullSecrets }}
+{{- end }}
+{{- if .Values.relatedImages }}
+        - name: RELATED_IMAGE_{{ $mongodbEnterpriseDatabaseImageEnv }}_{{ $databaseVersion | replace "." "_" | replace "-" "_" }}
+          value: "{{ .Values.registry.database }}/{{ .Values.database.name }}:{{ $databaseVersion }}"
+        - name: RELATED_IMAGE_{{ $initDatabaseImageRepositoryEnv }}_{{ $initDatabaseVersion | replace "." "_" | replace "-" "_" }}
+          value: "{{ .Values.registry.initDatabase }}/{{ .Values.initDatabase.name }}:{{ $initDatabaseVersion }}"
+        - name: RELATED_IMAGE_{{ $initOpsManagerImageRepositoryEnv }}_{{ $initOpsManagerVersion | replace "." "_" | replace "-" "_" }}
+          value: "{{ .Values.registry.initOpsManager }}/{{ .Values.initOpsManager.name }}:{{ $initOpsManagerVersion }}"
+        - name: RELATED_IMAGE_{{ $initAppDbImageRepositoryEnv }}_{{ $initAppDbVersion | replace "." "_" | replace "-" "_" }}
+          value: "{{ .Values.registry.initAppDb }}/{{ .Values.initAppDb.name }}:{{ $initAppDbVersion }}"
+  {{- range $version := .Values.relatedImages.agent }}
+        - name: RELATED_IMAGE_{{ $agentImageEnv }}_{{ $version | replace "." "_" | replace "-" "_" }}
+          value: "{{ $.Values.registry.agent }}/{{ $.Values.agent.name }}:{{ $version }}"
+  {{- end }}
+  {{- range $version := .Values.relatedImages.opsManager }}
+        - name: RELATED_IMAGE_{{ $opsManagerImageRepositoryEnv }}_{{ $version | replace "." "_" | replace "-" "_" }}
+          value: "{{ $.Values.registry.opsManager }}/{{ $.Values.opsManager.name }}:{{ $version }}"
+  {{- end }}
+  {{- range $version := .Values.relatedImages.mongodb }}
+        - name: RELATED_IMAGE_{{ $mongodbImageEnv }}_{{ $version | replace "." "_" | replace "-" "_" }}
+          value: "{{ $.Values.mongodb.repo }}/{{ $.Values.mongodb.name }}:{{ $version }}"
+  {{- end }}
 {{- end }}
 {{- if .Values.customEnvVars }}
   {{- range split "&" .Values.customEnvVars }}

--- a/charts/enterprise-operator/values-openshift.yaml
+++ b/charts/enterprise-operator/values-openshift.yaml
@@ -12,13 +12,10 @@ operator:
   name: mongodb-enterprise-operator
 
   # Name of the operator image
-  operator_image_name: enterprise-operator
-
-  # Name of the deployment of the operator pod
-  deployment_name: mongodb-enterprise-operator
+  operator_image_name: mongodb-enterprise-operator-ubi
 
   # Version of mongodb-enterprise-operator
-  version: 1.17.0
+  version: 1.17.1
 
   # The Custom Resources that will be watched by the Operator. Needs to be changed if only some of the CRDs are installed
   watchedResources:
@@ -34,31 +31,31 @@ operator:
 
 ## Database
 database:
-  name: enterprise-database
+  name: mongodb-enterprise-database-ubi
   version: 2.0.2
 
 initDatabase:
-  name: mongodb-enterprise-init-database
+  name: mongodb-enterprise-init-database-ubi
   version: 1.0.12
 
 ## Ops Manager
 opsManager:
-  name: mongodb-enterprise-ops-manager
+  name: mongodb-enterprise-ops-manager-ubi
 
 initOpsManager:
-  name: mongodb-enterprise-init-ops-manager
+  name: mongodb-enterprise-init-ops-manager-ubi
   version: 1.0.9
 
 initAppDb:
-  name: mongodb-enterprise-init-appdb
+  name: mongodb-enterprise-init-appdb-ubi
   version: 1.0.12
 
 agent:
-  name: mongodb-agent
+  name: mongodb-agent-ubi
   version: 11.12.0.7388-1
 
 mongodb:
-  name: mongodb-enterprise-appdb-database
+  name: mongodb-enterprise-appdb-database-ubi
   repo: quay.io/mongodb
 
 
@@ -67,16 +64,53 @@ registry:
   # The pull secret must be specified
   imagePullSecrets:
   pullPolicy: Always
-  database: registry.connect.redhat.com/mongodb
-  operator: registry.connect.redhat.com/mongodb
-  initDatabase: registry.connect.redhat.com/mongodb
-  initOpsManager: registry.connect.redhat.com/mongodb
-  opsManager: registry.connect.redhat.com/mongodb
-  initAppDb: registry.connect.redhat.com/mongodb
-  appDb: registry.connect.redhat.com/mongodb
-  agent: registry.connect.redhat.com/mongodb
+  database: quay.io/mongodb
+  operator: quay.io/mongodb
+  initDatabase: quay.io/mongodb
+  initOpsManager: quay.io/mongodb
+  opsManager: quay.io/mongodb
+  initAppDb: quay.io/mongodb
+  appDb: quay.io/mongodb
+  agent: quay.io/mongodb
 
-
-# Set this to false to disable subresource utilization
-# It might be required on some versions of Openshift
+# Versions listed here are used to populate RELATED_IMAGE_ env variables in the operator deployment.
+# Environment variables prefixed with RELATED_IMAGE_ are used by operator-sdk to generate relatedImages section
+# with sha256 digests pinning for certified operator bundle with disconnected environment feature enabled.
+# https://docs.openshift.com/container-platform/4.11/operators/operator_sdk/osdk-generating-csvs.html#olm-enabling-operator-for-restricted-network_osdk-generating-csvs
+relatedImages:
+  opsManager:
+  - 5.0.0
+  - 5.0.1
+  - 5.0.2
+  - 5.0.3
+  - 5.0.4
+  - 5.0.5
+  - 5.0.6
+  - 5.0.7
+  - 5.0.8
+  - 5.0.9
+  - 5.0.10
+  - 5.0.11
+  - 5.0.12
+  - 5.0.13
+  - 5.0.14
+  - 5.0.15
+  - 6.0.0
+  - 6.0.1
+  - 6.0.2
+  - 6.0.3
+  mongodb:
+  - 4.2.11-ent
+  - 4.2.2-ent
+  - 4.2.6-ent
+  - 4.2.8-ent
+  - 4.4.0-ent
+  - 4.4.11-ent
+  - 4.4.4-ent
+  - 5.0.1-ent
+  - 5.0.5-ent
+  agent:
+  - 11.0.5.6963-1
+  - 11.12.0.7388-1
+  - 12.0.4.7554-1
 subresourceEnabled: true

--- a/charts/enterprise-operator/values.yaml
+++ b/charts/enterprise-operator/values.yaml
@@ -18,7 +18,7 @@ operator:
   deployment_name: mongodb-enterprise-operator
 
   # Version of mongodb-enterprise-operator
-  version: 1.17.0
+  version: 1.17.1
 
   # The Custom Resources that will be watched by the Operator. Needs to be changed if only some of the CRDs are installed
   watchedResources:


### PR DESCRIPTION
## Kubernetes Enterprise Operator Release 1.17.1


This release patch has been created and it should be reviewed now.


You can add new commits to this patch if needed. After changes have
been reviewed, merge this PR for PCT to continue the release process.