### PR TITLE
Kubernetes Enterprise Operator Release 1.17.2

### DIFF
--- a/charts/enterprise-operator/Chart.yaml
+++ b/charts/enterprise-operator/Chart.yaml
@@ -1,8 +1,7 @@
----
 apiVersion: v2
 name: enterprise-operator
 description: MongoDB Kubernetes Enterprise Operator
-version: 1.17.1
+version: 1.17.2
 kubeVersion: '>=1.16-0'
 type: application
 keywords:

--- a/charts/enterprise-operator/templates/operator-roles.yaml
+++ b/charts/enterprise-operator/templates/operator-roles.yaml
@@ -109,6 +109,7 @@ rules:
 # definitions. The validating webhooks are optional so this can be removed if
 # necessary.
 ---
+{{- if not (lookup "rbac.authorization.k8s.io/v1" "ClusterRole" "" "mongodb-enterprise-operator-mongodb-webhook") }}
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -135,6 +136,7 @@ rules:
       - create
       - update
       - delete
+{{- end }}
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/charts/enterprise-operator/values-openshift.yaml
+++ b/charts/enterprise-operator/values-openshift.yaml
@@ -15,7 +15,7 @@ operator:
   operator_image_name: mongodb-enterprise-operator-ubi
 
   # Version of mongodb-enterprise-operator
-  version: 1.17.1
+  version: 1.17.2
 
   # The Custom Resources that will be watched by the Operator. Needs to be changed if only some of the CRDs are installed
   watchedResources:
@@ -29,13 +29,14 @@ operator:
 
   affinity: {}
 
-  resources:
-    requests:
-      cpu: 500m
-      memory: 200Mi
-    limits:
-      cpu: 1100m
-      memory: 1Gi
+# operator cpu requests and limits
+resources:
+  requests:
+    cpu: 500m
+    memory: 200Mi
+  limits:
+    cpu: 1100m
+    memory: 1Gi
 
 ## Database
 database:
@@ -44,7 +45,7 @@ database:
 
 initDatabase:
   name: mongodb-enterprise-init-database-ubi
-  version: 1.0.12
+  version: 1.0.13
 
 ## Ops Manager
 opsManager:
@@ -56,7 +57,7 @@ initOpsManager:
 
 initAppDb:
   name: mongodb-enterprise-init-appdb-ubi
-  version: 1.0.12
+  version: 1.0.13
 
 agent:
   name: mongodb-agent-ubi

--- a/charts/enterprise-operator/values.yaml
+++ b/charts/enterprise-operator/values.yaml
@@ -18,7 +18,7 @@ operator:
   deployment_name: mongodb-enterprise-operator
 
   # Version of mongodb-enterprise-operator
-  version: 1.17.1
+  version: 1.17.2
 
   # The Custom Resources that will be watched by the Operator. Needs to be changed if only some of the CRDs are installed
   watchedResources:
@@ -32,6 +32,7 @@ operator:
 
   affinity: {}
 
+  # operator cpu requests and limits
   resources:
     requests:
       cpu: 500m
@@ -55,7 +56,7 @@ database:
 
 initDatabase:
   name: mongodb-enterprise-init-database
-  version: 1.0.12
+  version: 1.0.13
 
 ## Ops Manager
 opsManager:
@@ -68,7 +69,7 @@ initOpsManager:
 ## Application Database
 initAppDb:
   name: mongodb-enterprise-init-appdb
-  version: 1.0.12
+  version: 1.0.13
 
 agent:
   name: mongodb-agent


### PR DESCRIPTION
## Kubernetes Enterprise Operator Release 1.17.2


This release patch has been created and it should be reviewed now.


You can add new commits to this patch if needed. After changes have
been reviewed, merge this PR for PCT to continue the release process.