### PR TITLE
add operator-class to only reconcile resources with mongodb.com/atlas-operator-class=<operator-class> annotation

### DIFF
--- a/charts/atlas-operator/templates/deployment.yaml
+++ b/charts/atlas-operator/templates/deployment.yaml
@@ -30,6 +30,7 @@ spec:
         - name: manager
           args:
             - --atlas-domain={{ .Values.atlasURI }}
+            - --revision={{ .Values.revision }}
             - "--health-probe-bind-address=:8081"
             - "--metrics-bind-address=:8080"
             - "--leader-elect"

--- a/charts/atlas-operator/templates/deployment.yaml
+++ b/charts/atlas-operator/templates/deployment.yaml
@@ -30,7 +30,7 @@ spec:
         - name: manager
           args:
             - --atlas-domain={{ .Values.atlasURI }}
-            - --revision={{ .Values.revision }}
+            - --operator-class={{ .Values.operatorClass }}
             - "--health-probe-bind-address=:8081"
             - "--metrics-bind-address=:8080"
             - "--leader-elect"

--- a/charts/atlas-operator/values.yaml
+++ b/charts/atlas-operator/values.yaml
@@ -18,6 +18,9 @@ mongodb-atlas-operator-crds:
 # atlasURI is the URI of the MongoDB Atlas. You should not change this value.
 atlasURI: https://cloud.mongodb.com/
 
+# revision is used to only reconsile resources with the mongodb.com/atlas-revision=<revision> annotation
+revision: ""
+
 # globalConnectionSecret is a default "global" Secret containing Atlas
 # authentication information.
 #

--- a/charts/atlas-operator/values.yaml
+++ b/charts/atlas-operator/values.yaml
@@ -18,8 +18,8 @@ mongodb-atlas-operator-crds:
 # atlasURI is the URI of the MongoDB Atlas. You should not change this value.
 atlasURI: https://cloud.mongodb.com/
 
-# revision is used to only reconsile resources with the mongodb.com/atlas-revision=<revision> annotation
-revision: ""
+# operatorClass is used to only reconsile resources with the mongodb.com/atlas-operator-class=<operator-class> annotation
+operatorClass: ""
 
 # globalConnectionSecret is a default "global" Secret containing Atlas
 # authentication information.


### PR DESCRIPTION
This adds revision argument implemented here: https://github.com/mongodb/mongodb-atlas-kubernetes/pull/842