### PR TITLE
Moved leases.coordination.k8s.io to its own proxy-role rule

### DIFF
--- a/charts/atlas-operator/templates/roles.yaml
+++ b/charts/atlas-operator/templates/roles.yaml
@@ -73,9 +73,19 @@ metadata:
 rules:
   - apiGroups:
       - ""
-      - coordination.k8s.io
     resources:
       - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
       - leases
     verbs:
       - get


### PR DESCRIPTION
`lease` RBAC cannot be installed in newer versions of k8s

See:

https://github.com/operator-framework/operator-sdk/pull/4835/files https://github.com/operator-framework/operator-sdk/releases/tag/v1.7.1


Closes #219

### All Submissions:

* [x] Have you opened an Issue before filing this PR?
* [x] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
