### PR TITLE
Kubernetes Enterprise Operator Release 1.20.1

### DIFF
--- a/charts/enterprise-operator/Chart.yaml
+++ b/charts/enterprise-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: enterprise-operator
 description: MongoDB Kubernetes Enterprise Operator
-version: 1.19.1
+version: 1.20.1
 kubeVersion: '>=1.16-0'
 type: application
 keywords:

--- a/charts/enterprise-operator/crds/mongodb.com_mongodb.yaml
+++ b/charts/enterprise-operator/crds/mongodb.com_mongodb.yaml
@@ -61,6 +61,10 @@ spec:
                 x-kubernetes-preserve-unknown-fields: true
               agent:
                 properties:
+                  logLevel:
+                    type: string
+                  maxLogFileDurationHours:
+                    type: integer
                   startupOptions:
                     additionalProperties:
                       type: string
@@ -215,6 +219,10 @@ spec:
                     x-kubernetes-preserve-unknown-fields: true
                   agent:
                     properties:
+                      logLevel:
+                        type: string
+                      maxLogFileDurationHours:
+                        type: integer
                       startupOptions:
                         additionalProperties:
                           type: string
@@ -360,6 +368,10 @@ spec:
                     x-kubernetes-preserve-unknown-fields: true
                   agent:
                     properties:
+                      logLevel:
+                        type: string
+                      maxLogFileDurationHours:
+                        type: integer
                       startupOptions:
                         additionalProperties:
                           type: string
@@ -736,6 +748,10 @@ spec:
                     x-kubernetes-preserve-unknown-fields: true
                   agent:
                     properties:
+                      logLevel:
+                        type: string
+                      maxLogFileDurationHours:
+                        type: integer
                       startupOptions:
                         additionalProperties:
                           type: string

--- a/charts/enterprise-operator/crds/mongodb.com_mongodbmulticluster.yaml
+++ b/charts/enterprise-operator/crds/mongodb.com_mongodbmulticluster.yaml
@@ -52,6 +52,10 @@ spec:
                 x-kubernetes-preserve-unknown-fields: true
               agent:
                 properties:
+                  logLevel:
+                    type: string
+                  maxLogFileDurationHours:
+                    type: integer
                   startupOptions:
                     additionalProperties:
                       type: string

--- a/charts/enterprise-operator/crds/mongodb.com_opsmanagers.yaml
+++ b/charts/enterprise-operator/crds/mongodb.com_opsmanagers.yaml
@@ -80,6 +80,10 @@ spec:
                     description: specify startup flags for the AutomationAgent and
                       MonitoringAgent
                     properties:
+                      logLevel:
+                        type: string
+                      maxLogFileDurationHours:
+                        type: integer
                       startupOptions:
                         additionalProperties:
                           type: string
@@ -151,6 +155,20 @@ spec:
                     - ERROR
                     - FATAL
                     type: string
+                  memberConfig:
+                    description: MemberConfig
+                    items:
+                      properties:
+                        priority:
+                          type: string
+                        tags:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        votes:
+                          type: integer
+                      type: object
+                    type: array
                   members:
                     description: Amount of members for this MongoDB Replica Set
                     maximum: 50
@@ -160,6 +178,10 @@ spec:
                     description: specify startup flags for just the MonitoringAgent.
                       These take precedence over the flags set in AutomationAgent
                     properties:
+                      logLevel:
+                        type: string
+                      maxLogFileDurationHours:
+                        type: integer
                       startupOptions:
                         additionalProperties:
                           type: string
@@ -237,10 +259,6 @@ spec:
                         type: object
                         x-kubernetes-preserve-unknown-fields: true
                     type: object
-                  project:
-                    description: 'Deprecated: This has been replaced by the PrivateCloudConfig
-                      which should be used instead'
-                    type: string
                   prometheus:
                     description: Enables Prometheus integration on the AppDB.
                     properties:

--- a/charts/enterprise-operator/templates/operator.yaml
+++ b/charts/enterprise-operator/templates/operator.yaml
@@ -140,6 +140,12 @@ spec:
               value: {{ .Values.mongodb.name }}
             - name: MONGODB_REPO_URL
               value: {{ .Values.mongodb.repo }}
+            - name: MDB_IMAGE_TYPE
+              value: {{ .Values.mongodb.imageType }}
+    {{- if eq .Values.mongodb.appdbAssumeOldFormat true }}
+            - name: MDB_APPDB_ASSUME_OLD_FORMAT
+              value: 'true'
+    {{- end }}
     {{- if eq .Values.multiCluster.performFailOver true }}
             - name: PERFORM_FAILOVER
               value: 'true'
@@ -165,9 +171,15 @@ spec:
             - name: RELATED_IMAGE_{{ $opsManagerImageRepositoryEnv }}_{{ $version | replace "." "_" | replace "-" "_" }}
               value: "{{ $.Values.registry.opsManager }}/{{ $.Values.opsManager.name }}:{{ $version }}"
       {{- end }}
+      # since the official server images end with a different suffix we can re-use the same $mongodbImageEnv
       {{- range $version := .Values.relatedImages.mongodb }}
             - name: RELATED_IMAGE_{{ $mongodbImageEnv }}_{{ $version | replace "." "_" | replace "-" "_" }}
               value: "{{ $.Values.mongodb.repo }}/{{ $.Values.mongodb.name }}:{{ $version }}"
+      {{- end }}
+      # mongodbLegacyAppDb will be deleted in 1.23 release 
+      {{- range $version := .Values.relatedImages.mongodbLegacyAppDb }}
+            - name: RELATED_IMAGE_{{ $mongodbImageEnv }}_{{ $version | replace "." "_" | replace "-" "_" }}
+              value: "{{ $.Values.mongodbLegacyAppDb.repo }}/{{ $.Values.mongodbLegacyAppDb.name }}:{{ $version }}"
       {{- end }}
     {{- end }}
     {{- if .Values.customEnvVars }}

--- a/charts/enterprise-operator/values-openshift.yaml
+++ b/charts/enterprise-operator/values-openshift.yaml
@@ -8,14 +8,14 @@ operator:
   # Execution environment for the operator, dev or prod. Use dev for more verbose logging
   env: prod
 
-  # Name that will be assigned to most of internal Kubernetes objects like ServiceAccount, Role etc.
+  # Name that will be assigned to most of the internal Kubernetes objects like ServiceAccount, Role etc.
   name: mongodb-enterprise-operator
 
   # Name of the operator image
   operator_image_name: mongodb-enterprise-operator-ubi
 
   # Version of mongodb-enterprise-operator
-  version: 1.19.1
+  version: 1.20.1
 
   # The Custom Resources that will be watched by the Operator. Needs to be changed if only some of the CRDs are installed
   watchedResources:
@@ -45,7 +45,7 @@ database:
 
 initDatabase:
   name: mongodb-enterprise-init-database-ubi
-  version: 1.0.15
+  version: 1.0.17
 
 ## Ops Manager
 opsManager:
@@ -53,20 +53,20 @@ opsManager:
 
 initOpsManager:
   name: mongodb-enterprise-init-ops-manager-ubi
-  version: 1.0.10
+  version: 1.0.11
 
 initAppDb:
   name: mongodb-enterprise-init-appdb-ubi
-  version: 1.0.15
+  version: 1.0.17
 
 agent:
   name: mongodb-agent-ubi
-  version: 12.0.15.7646-1
+  version: 12.0.21.7698-1
 
 mongodb:
-  name: mongodb-enterprise-appdb-database-ubi
+  name: mongodb-enterprise-server
   repo: quay.io/mongodb
-
+  appdbAssumeOldFormat: false
 
 ## Registry
 registry:
@@ -84,7 +84,7 @@ registry:
 
 # Versions listed here are used to populate RELATED_IMAGE_ env variables in the operator deployment.
 # Environment variables prefixed with RELATED_IMAGE_ are used by operator-sdk to generate relatedImages section
-# with sha256 digests pinning for certified operator bundle with disconnected environment feature enabled.
+# with sha256 digests pinning for the certified operator bundle with disconnected environment feature enabled.
 # https://docs.openshift.com/container-platform/4.11/operators/operator_sdk/osdk-generating-csvs.html#olm-enabling-operator-for-restricted-network_osdk-generating-csvs
 relatedImages:
   opsManager:
@@ -109,6 +109,7 @@ relatedImages:
   - 5.0.18
   - 5.0.19
   - 5.0.20
+  - 5.0.21
   - 6.0.0
   - 6.0.1
   - 6.0.2
@@ -121,20 +122,78 @@ relatedImages:
   - 6.0.9
   - 6.0.10
   - 6.0.11
+  - 6.0.12
+  - 6.0.13
+  - 6.0.14
   mongodb:
-  - 4.2.11-ent
-  - 4.2.2-ent
-  - 4.2.6-ent
-  - 4.2.8-ent
-  - 4.4.0-ent
-  - 4.4.11-ent
-  - 4.4.4-ent
-  - 5.0.1-ent
-  - 5.0.5-ent
-  - 5.0.7-ent
+  - 4.4.0-ubi8
+  - 4.4.1-ubi8
+  - 4.4.2-ubi8
+  - 4.4.3-ubi8
+  - 4.4.4-ubi8
+  - 4.4.5-ubi8
+  - 4.4.6-ubi8
+  - 4.4.7-ubi8
+  - 4.4.8-ubi8
+  - 4.4.9-ubi8
+  - 4.4.10-ubi8
+  - 4.4.11-ubi8
+  - 4.4.12-ubi8
+  - 4.4.13-ubi8
+  - 4.4.14-ubi8
+  - 4.4.15-ubi8
+  - 4.4.16-ubi8
+  - 4.4.17-ubi8
+  - 4.4.18-ubi8
+  - 4.4.19-ubi8
+  - 4.4.20-ubi8
+  - 4.4.21-ubi8
+  - 5.0.0-ubi8
+  - 5.0.1-ubi8
+  - 5.0.2-ubi8
+  - 5.0.3-ubi8
+  - 5.0.4-ubi8
+  - 5.0.5-ubi8
+  - 5.0.6-ubi8
+  - 5.0.7-ubi8
+  - 5.0.8-ubi8
+  - 5.0.9-ubi8
+  - 5.0.10-ubi8
+  - 5.0.11-ubi8
+  - 5.0.12-ubi8
+  - 5.0.13-ubi8
+  - 5.0.14-ubi8
+  - 5.0.15-ubi8
+  - 5.0.16-ubi8
+  - 5.0.17-ubi8
+  - 5.0.18-ubi8
+  - 6.0.0-ubi8
+  - 6.0.1-ubi8
+  - 6.0.2-ubi8
+  - 6.0.3-ubi8
+  - 6.0.4-ubi8
+  - 6.0.5-ubi8
   agent:
   - 11.0.5.6963-1
   - 11.12.0.7388-1
   - 12.0.4.7554-1
   - 12.0.15.7646-1
+  - 12.0.20.7686-1
+  - 12.0.21.7698-1
+  mongodbLegacyAppDb:
+  - 4.2.11-ent
+  - 4.2.2-ent
+  - 4.2.24-ent
+  - 4.2.6-ent
+  - 4.2.8-ent
+  - 4.4.0-ent
+  - 4.4.11-ent
+  - 4.4.4-ent
+  - 4.4.21-ent
+  - 5.0.1-ent
+  - 5.0.5-ent
+  - 5.0.6-ent
+  - 5.0.7-ent
+  - 5.0.14-ent
+  - 5.0.18-ent
 subresourceEnabled: true

--- a/charts/enterprise-operator/values.yaml
+++ b/charts/enterprise-operator/values.yaml
@@ -18,7 +18,7 @@ operator:
   deployment_name: mongodb-enterprise-operator
 
   # Version of mongodb-enterprise-operator
-  version: 1.19.1
+  version: 1.20.1
 
   # The Custom Resources that will be watched by the Operator. Needs to be changed if only some of the CRDs are installed
   watchedResources:
@@ -53,33 +53,39 @@ operator:
 
 ## Database
 database:
-  name: mongodb-enterprise-database
+  name: mongodb-enterprise-database-ubi
   version: 2.0.2
 
 initDatabase:
-  name: mongodb-enterprise-init-database
-  version: 1.0.15
+  name: mongodb-enterprise-init-database-ubi
+  version: 1.0.17
 
 ## Ops Manager
 opsManager:
-  name: mongodb-enterprise-ops-manager
+  name: mongodb-enterprise-ops-manager-ubi
 
 initOpsManager:
-  name: mongodb-enterprise-init-ops-manager
-  version: 1.0.10
+  name: mongodb-enterprise-init-ops-manager-ubi
+  version: 1.0.11
 
 ## Application Database
 initAppDb:
-  name: mongodb-enterprise-init-appdb
-  version: 1.0.15
+  name: mongodb-enterprise-init-appdb-ubi
+  version: 1.0.17
 
 agent:
-  name: mongodb-agent
-  version: 12.0.15.7646-1
+  name: mongodb-agent-ubi
+  version: 12.0.21.7698-1
+
+mongodbLegacyAppDb:
+  name: mongodb-enterprise-appdb-database-ubi
+  repo: quay.io/mongodb
 
 mongodb:
-  name: mongodb-enterprise-appdb-database
+  name: mongodb-enterprise-server
   repo: quay.io/mongodb
+  appdbAssumeOldFormat: false
+  imageType: ubi8
 
 
 ## Registry


### PR DESCRIPTION
## Kubernetes Enterprise Operator Release 1.20.1


This release patch has been created and it should be reviewed now.


You can add new commits to this patch if needed. After changes have
been reviewed, merge this PR for PCT to continue the release process.