### PR TITLE
[community-operator] Add support of securityContext for operator pod and container

### DIFF
--- a/charts/community-operator/templates/operator.yaml
+++ b/charts/community-operator/templates/operator.yaml
@@ -72,7 +72,12 @@ spec:
           name: {{ .Values.operator.deploymentName }}
           resources:
             {{- toYaml .Values.operator.resources | nindent 12 }}
+          {{- if .Values.operator.securityContext }}
           securityContext:
-            readOnlyRootFilesystem: true
-            runAsUser: 2000
+            {{- toYaml .Values.operator.securityContext | nindent 12 }}
+          {{- end }}
+      {{- if .Values.operator.podSecurityContext }}
+      securityContext:
+        {{- toYaml .Values.operator.podSecurityContext | nindent 8 }}
+      {{- end }}
       serviceAccountName: {{ .Values.operator.name }}

--- a/charts/community-operator/values.yaml
+++ b/charts/community-operator/values.yaml
@@ -40,12 +40,7 @@ operator:
     runAsNonRoot: true
     runAsUser: 2000
 
-  securityContext:
-    capabilities:
-      drop:
-        - ALL
-    allowPrivilegeEscalation: false
-    readOnlyRootFilesystem: true
+  securityContext: {}
 
 ## Operator's database
 database:

--- a/charts/community-operator/values.yaml
+++ b/charts/community-operator/values.yaml
@@ -36,6 +36,17 @@ operator:
   # - name: CLUSTER_DOMAIN
   #   value: my-cluster.domain
 
+  podSecurityContext:
+    runAsNonRoot: true
+    runAsUser: 2000
+
+  securityContext:
+    capabilities:
+      drop:
+        - ALL
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
+
 ## Operator's database
 database:
   name: mongodb-database


### PR DESCRIPTION
Closes #236

This PR adds two variables which allow to customize securityContext:
- `operator.securityContext`  (for the container level)
- `operator.podSecurityContext`  (for the pod level) 

These vars have default values, which are backward compatible with previous behavior: both `readOnlyRootFilesystem: true` and `runAsUser: 2000` are preserved. New values added by default do not break the functionality and only improve the security posture of the operator pod in runtime.

Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/

### All Submissions:

* [x] Have you opened an Issue before filing this PR?
* [x] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
