### PR TITLE
Kubernetes Enterprise Operator Release 1.21.0

### DIFF
--- a/charts/enterprise-operator/Chart.yaml
+++ b/charts/enterprise-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: enterprise-operator
 description: MongoDB Kubernetes Enterprise Operator
-version: 1.20.1
+version: 1.21.0
 kubeVersion: '>=1.16-0'
 type: application
 keywords:

--- a/charts/enterprise-operator/crds/mongodb.com_mongodb.yaml
+++ b/charts/enterprise-operator/crds/mongodb.com_mongodb.yaml
@@ -647,6 +647,13 @@ spec:
                         type: object
                       modes:
                         items:
+                          enum:
+                          - X509
+                          - SCRAM
+                          - SCRAM-SHA-1
+                          - MONGODB-CR
+                          - SCRAM-SHA-256
+                          - LDAP
                           type: string
                         type: array
                       requireClientTLSAuthentication:
@@ -875,6 +882,19 @@ spec:
                   is specified at cluster level under "clusterSpecList" that takes
                   precedence over the global one
                 properties:
+                  metadata:
+                    description: StatefulSetMetadataWrapper is a wrapper around Labels
+                      and Annotations
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        type: object
+                    type: object
                   spec:
                     type: object
                     x-kubernetes-preserve-unknown-fields: true

--- a/charts/enterprise-operator/crds/mongodb.com_mongodbmulticluster.yaml
+++ b/charts/enterprise-operator/crds/mongodb.com_mongodbmulticluster.yaml
@@ -267,6 +267,19 @@ spec:
                         StatefulSet that should be merged into the operator created
                         one.
                       properties:
+                        metadata:
+                          description: StatefulSetMetadataWrapper is a wrapper around
+                            Labels and Annotations
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            labels:
+                              additionalProperties:
+                                type: string
+                              type: object
+                          type: object
                         spec:
                           type: object
                           x-kubernetes-preserve-unknown-fields: true
@@ -509,6 +522,13 @@ spec:
                         type: object
                       modes:
                         items:
+                          enum:
+                          - X509
+                          - SCRAM
+                          - SCRAM-SHA-1
+                          - MONGODB-CR
+                          - SCRAM-SHA-256
+                          - LDAP
                           type: string
                         type: array
                       requireClientTLSAuthentication:
@@ -604,6 +624,19 @@ spec:
                   is specified at cluster level under "clusterSpecList" that takes
                   precedence over the global one
                 properties:
+                  metadata:
+                    description: StatefulSetMetadataWrapper is a wrapper around Labels
+                      and Annotations
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        type: object
+                    type: object
                   spec:
                     type: object
                     x-kubernetes-preserve-unknown-fields: true

--- a/charts/enterprise-operator/crds/mongodb.com_opsmanagers.yaml
+++ b/charts/enterprise-operator/crds/mongodb.com_opsmanagers.yaml
@@ -122,6 +122,97 @@ spec:
                     type: object
                   clusterDomain:
                     type: string
+                  clusterSpecList:
+                    items:
+                      description: ClusterSpecItem is the mongodb multi-cluster spec
+                        that is specific to a particular Kubernetes cluster, this
+                        maps to the statefulset created in each cluster
+                      properties:
+                        clusterName:
+                          description: ClusterName is name of the cluster where the
+                            MongoDB Statefulset will be scheduled, the name should
+                            have a one on one mapping with the service-account created
+                            in the central cluster to talk to the workload clusters.
+                          type: string
+                        exposedExternally:
+                          description: 'DEPRECATED: use ExternalAccessConfiguration
+                            instead'
+                          type: boolean
+                        externalAccess:
+                          description: ExternalAccessConfiguration provides external
+                            access configuration for Multi-Cluster.
+                          properties:
+                            externalDomain:
+                              description: An external domain that is used for exposing
+                                MongoDB to the outside world.
+                              type: string
+                            externalService:
+                              description: Provides a way to override the default
+                                (NodePort) Service
+                              properties:
+                                annotations:
+                                  additionalProperties:
+                                    type: string
+                                  description: A map of annotations that shall be
+                                    added to the externally available Service.
+                                  type: object
+                                spec:
+                                  description: A wrapper for the Service spec object.
+                                  type: object
+                                  x-kubernetes-preserve-unknown-fields: true
+                              type: object
+                          type: object
+                        memberConfig:
+                          description: MemberConfig
+                          items:
+                            properties:
+                              priority:
+                                type: string
+                              tags:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                              votes:
+                                type: integer
+                            type: object
+                          type: array
+                          x-kubernetes-preserve-unknown-fields: true
+                        members:
+                          description: Amount of members for this MongoDB Replica
+                            Set
+                          type: integer
+                        service:
+                          description: this is an optional service, it will get the
+                            name "<rsName>-service" in case not provided
+                          type: string
+                        statefulSet:
+                          description: StatefulSetConfiguration holds the optional
+                            custom StatefulSet that should be merged into the operator
+                            created one.
+                          properties:
+                            metadata:
+                              description: StatefulSetMetadataWrapper is a wrapper
+                                around Labels and Annotations
+                              properties:
+                                annotations:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                labels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              type: object
+                            spec:
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
+                          required:
+                          - spec
+                          type: object
+                      required:
+                      - members
+                      type: object
+                    type: array
                   connectivity:
                     properties:
                       replicaSetHorizons:
@@ -416,6 +507,13 @@ spec:
                             type: object
                           modes:
                             items:
+                              enum:
+                              - X509
+                              - SCRAM
+                              - SCRAM-SHA-1
+                              - MONGODB-CR
+                              - SCRAM-SHA-256
+                              - LDAP
                               type: string
                             type: array
                           requireClientTLSAuthentication:
@@ -508,7 +606,12 @@ spec:
                     type: object
                   service:
                     description: this is an optional service, it will get the name
-                      "<rsName>-service" in case not provided
+                      "<rsName>-svc" in case not provided
+                    type: string
+                  topology:
+                    enum:
+                    - SingleCluster
+                    - MultiCluster
                     type: string
                   type:
                     enum:
@@ -687,12 +790,40 @@ spec:
                             type: string
                           type: array
                         customCertificate:
-                          description: Set this to "true" when you have custom certificates
-                            for your S3 buckets
+                          description: 'Set this to "true" to use the appDBCa as a
+                            CA to access S3. Deprecated: This has been replaced by
+                            CustomCertificateSecretRefs, In the future all custom
+                            certificates, which includes the appDBCa for s3Config
+                            should be configured in CustomCertificateSecretRefs instead.'
                           type: boolean
+                        customCertificateSecretRefs:
+                          description: CustomCertificateSecretRefs is a list of valid
+                            Certificate Authority certificate secrets that apply to
+                            the associated S3 bucket.
+                          items:
+                            description: SecretKeySelector selects a key of a Secret.
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key
+                                  must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          type: array
                         irsaEnabled:
-                          description: 'This is only set to "true" when user is running
-                            in EKS and is using AWS IRSA to configure S3 snapshot
+                          description: 'This is only set to "true" when a user is
+                            running in EKS and is using AWS IRSA to configure S3 snapshot
                             store. For more details refer this: https://aws.amazon.com/blogs/opensource/introducing-fine-grained-iam-roles-service-accounts/'
                           type: boolean
                         mongodbResourceRef:
@@ -745,12 +876,40 @@ spec:
                             type: string
                           type: array
                         customCertificate:
-                          description: Set this to "true" when you have custom certificates
-                            for your S3 buckets
+                          description: 'Set this to "true" to use the appDBCa as a
+                            CA to access S3. Deprecated: This has been replaced by
+                            CustomCertificateSecretRefs, In the future all custom
+                            certificates, which includes the appDBCa for s3Config
+                            should be configured in CustomCertificateSecretRefs instead.'
                           type: boolean
+                        customCertificateSecretRefs:
+                          description: CustomCertificateSecretRefs is a list of valid
+                            Certificate Authority certificate secrets that apply to
+                            the associated S3 bucket.
+                          items:
+                            description: SecretKeySelector selects a key of a Secret.
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key
+                                  must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          type: array
                         irsaEnabled:
-                          description: 'This is only set to "true" when user is running
-                            in EKS and is using AWS IRSA to configure S3 snapshot
+                          description: 'This is only set to "true" when a user is
+                            running in EKS and is using AWS IRSA to configure S3 snapshot
                             store. For more details refer this: https://aws.amazon.com/blogs/opensource/introducing-fine-grained-iam-roles-service-accounts/'
                           type: boolean
                         mongodbResourceRef:
@@ -799,6 +958,19 @@ spec:
                       StatefulSet that should be merged into the operator created
                       one.
                     properties:
+                      metadata:
+                        description: StatefulSetMetadataWrapper is a wrapper around
+                          Labels and Annotations
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          labels:
+                            additionalProperties:
+                              type: string
+                            type: object
+                        type: object
                       spec:
                         type: object
                         x-kubernetes-preserve-unknown-fields: true
@@ -886,6 +1058,19 @@ spec:
               statefulSet:
                 description: Configure custom StatefulSet configuration
                 properties:
+                  metadata:
+                    description: StatefulSetMetadataWrapper is a wrapper around Labels
+                      and Annotations
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        type: object
+                    type: object
                   spec:
                     type: object
                     x-kubernetes-preserve-unknown-fields: true

--- a/charts/enterprise-operator/templates/operator.yaml
+++ b/charts/enterprise-operator/templates/operator.yaml
@@ -85,7 +85,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
     {{- end }}
-            - name: CURRENT_NAMESPACE
+            - name: NAMESPACE
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
@@ -176,7 +176,7 @@ spec:
             - name: RELATED_IMAGE_{{ $mongodbImageEnv }}_{{ $version | replace "." "_" | replace "-" "_" }}
               value: "{{ $.Values.mongodb.repo }}/{{ $.Values.mongodb.name }}:{{ $version }}"
       {{- end }}
-      # mongodbLegacyAppDb will be deleted in 1.23 release 
+      # mongodbLegacyAppDb will be deleted in 1.23 release
       {{- range $version := .Values.relatedImages.mongodbLegacyAppDb }}
             - name: RELATED_IMAGE_{{ $mongodbImageEnv }}_{{ $version | replace "." "_" | replace "-" "_" }}
               value: "{{ $.Values.mongodbLegacyAppDb.repo }}/{{ $.Values.mongodbLegacyAppDb.name }}:{{ $version }}"

--- a/charts/enterprise-operator/values-openshift.yaml
+++ b/charts/enterprise-operator/values-openshift.yaml
@@ -15,7 +15,7 @@ operator:
   operator_image_name: mongodb-enterprise-operator-ubi
 
   # Version of mongodb-enterprise-operator
-  version: 1.20.1
+  version: 1.21.0
 
   # The Custom Resources that will be watched by the Operator. Needs to be changed if only some of the CRDs are installed
   watchedResources:
@@ -45,7 +45,7 @@ database:
 
 initDatabase:
   name: mongodb-enterprise-init-database-ubi
-  version: 1.0.17
+  version: 1.0.18
 
 ## Ops Manager
 opsManager:
@@ -53,21 +53,20 @@ opsManager:
 
 initOpsManager:
   name: mongodb-enterprise-init-ops-manager-ubi
-  version: 1.0.11
+  version: 1.0.12
 
 initAppDb:
   name: mongodb-enterprise-init-appdb-ubi
-  version: 1.0.17
+  version: 1.0.18
 
 agent:
   name: mongodb-agent-ubi
-  version: 12.0.21.7698-1
+  version: 12.0.25.7724-1
 
 mongodb:
   name: mongodb-enterprise-server
   repo: quay.io/mongodb
   appdbAssumeOldFormat: false
-  imageType: ubi8
 
 ## Registry
 registry:
@@ -111,6 +110,7 @@ relatedImages:
   - 5.0.19
   - 5.0.20
   - 5.0.21
+  - 5.0.22
   - 6.0.0
   - 6.0.1
   - 6.0.2
@@ -126,6 +126,9 @@ relatedImages:
   - 6.0.12
   - 6.0.13
   - 6.0.14
+  - 6.0.15
+  - 6.0.16
+  - 6.0.17
   mongodb:
   - 4.4.0-ubi8
   - 4.4.1-ubi8
@@ -181,6 +184,9 @@ relatedImages:
   - 12.0.15.7646-1
   - 12.0.20.7686-1
   - 12.0.21.7698-1
+  - 12.0.23.7711-1
+  - 12.0.24.7719-1
+  - 12.0.25.7724-1
   mongodbLegacyAppDb:
   - 4.2.11-ent
   - 4.2.2-ent

--- a/charts/enterprise-operator/values.yaml
+++ b/charts/enterprise-operator/values.yaml
@@ -18,7 +18,7 @@ operator:
   deployment_name: mongodb-enterprise-operator
 
   # Version of mongodb-enterprise-operator
-  version: 1.20.1
+  version: 1.21.0
 
   # The Custom Resources that will be watched by the Operator. Needs to be changed if only some of the CRDs are installed
   watchedResources:
@@ -58,7 +58,7 @@ database:
 
 initDatabase:
   name: mongodb-enterprise-init-database-ubi
-  version: 1.0.17
+  version: 1.0.18
 
 ## Ops Manager
 opsManager:
@@ -66,16 +66,16 @@ opsManager:
 
 initOpsManager:
   name: mongodb-enterprise-init-ops-manager-ubi
-  version: 1.0.11
+  version: 1.0.12
 
 ## Application Database
 initAppDb:
   name: mongodb-enterprise-init-appdb-ubi
-  version: 1.0.17
+  version: 1.0.18
 
 agent:
   name: mongodb-agent-ubi
-  version: 12.0.21.7698-1
+  version: 12.0.25.7724-1
 
 mongodbLegacyAppDb:
   name: mongodb-enterprise-appdb-database-ubi


### PR DESCRIPTION
## Kubernetes Enterprise Operator Release 1.21.0


This release patch has been created and it should be reviewed now.


You can add new commits to this patch if needed. After changes have
been reviewed, merge this PR for PCT to continue the release process.