### PR TITLE
Kubernetes Enterprise Operator Release 1.22.0

### DIFF
--- a/charts/enterprise-operator/Chart.yaml
+++ b/charts/enterprise-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: enterprise-operator
 description: MongoDB Kubernetes Enterprise Operator
-version: 1.21.0
+version: 1.22.0
 kubeVersion: '>=1.16-0'
 type: application
 keywords:

--- a/charts/enterprise-operator/crds/mongodb.com_opsmanagers.yaml
+++ b/charts/enterprise-operator/crds/mongodb.com_opsmanagers.yaml
@@ -71,29 +71,75 @@ spec:
               applicationDatabase:
                 properties:
                   additionalMongodConfig:
-                    description: 'AdditionalMongodConfig is additional configuration
+                    description: 'AdditionalMongodConfig are additional configurations
                       that can be passed to each data-bearing mongod at runtime. Uses
                       the same structure as the mongod configuration file: https://docs.mongodb.com/manual/reference/configuration-options/'
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
                   agent:
-                    description: specify startup flags for the AutomationAgent and
-                      MonitoringAgent
+                    description: specify configuration like startup flags and automation
+                      config settings for the AutomationAgent and MonitoringAgent
                     properties:
                       logLevel:
                         type: string
+                      logRotate:
+                        description: LogRotate if enabled, will enable LogRotate for
+                          all processes.
+                        properties:
+                          includeAuditLogsWithMongoDBLogs:
+                            description: set to 'true' to have the Automation Agent
+                              rotate the audit files along with mongodb log files
+                            type: boolean
+                          numTotal:
+                            description: maximum number of log files to have total
+                            type: integer
+                          numUncompressed:
+                            description: maximum number of log files to leave uncompressed
+                            type: integer
+                          percentOfDiskspace:
+                            description: Maximum percentage of the total disk space
+                              these log files should take up. The string needs to
+                              be able to be converted to float64
+                            type: string
+                          sizeThresholdMB:
+                            description: Maximum size for an individual log file before
+                              rotation. The string needs to be able to be converted
+                              to float64. Fractional values of MB are supported.
+                            type: string
+                          timeThresholdHrs:
+                            description: maximum hours for an individual log file
+                              before rotation
+                            type: integer
+                        required:
+                        - sizeThresholdMB
+                        - timeThresholdHrs
+                        type: object
                       maxLogFileDurationHours:
                         type: integer
                       startupOptions:
                         additionalProperties:
                           type: string
                         type: object
+                      systemLog:
+                        description: SystemLog configures system log of mongod
+                        properties:
+                          destination:
+                            type: string
+                          logAppend:
+                            type: boolean
+                          path:
+                            type: string
+                        required:
+                        - destination
+                        - logAppend
+                        - path
+                        type: object
                     type: object
                   automationConfig:
                     description: AutomationConfigOverride holds any fields that will
                       be merged on top of the Automation Config that the operator
-                      creates for the AppDB. Currently only the process.disabled field
-                      is recognized.
+                      creates for the AppDB. Currently only the process.disabled and
+                      logRotate field is recognized.
                     properties:
                       processes:
                         items:
@@ -102,6 +148,43 @@ spec:
                           properties:
                             disabled:
                               type: boolean
+                            logRotate:
+                              description: CrdLogRotate is the crd definition of LogRotate
+                                including fields in strings while the agent supports
+                                them as float64
+                              properties:
+                                includeAuditLogsWithMongoDBLogs:
+                                  description: set to 'true' to have the Automation
+                                    Agent rotate the audit files along with mongodb
+                                    log files
+                                  type: boolean
+                                numTotal:
+                                  description: maximum number of log files to have
+                                    total
+                                  type: integer
+                                numUncompressed:
+                                  description: maximum number of log files to leave
+                                    uncompressed
+                                  type: integer
+                                percentOfDiskspace:
+                                  description: Maximum percentage of the total disk
+                                    space these log files should take up. The string
+                                    needs to be able to be converted to float64
+                                  type: string
+                                sizeThresholdMB:
+                                  description: Maximum size for an individual log
+                                    file before rotation. The string needs to be able
+                                    to be converted to float64. Fractional values
+                                    of MB are supported.
+                                  type: string
+                                timeThresholdHrs:
+                                  description: maximum hours for an individual log
+                                    file before rotation
+                                  type: integer
+                              required:
+                              - sizeThresholdMB
+                              - timeThresholdHrs
+                              type: object
                             name:
                               type: string
                           required:
@@ -266,8 +349,9 @@ spec:
                     minimum: 3
                     type: integer
                   monitoringAgent:
-                    description: specify startup flags for just the MonitoringAgent.
-                      These take precedence over the flags set in AutomationAgent
+                    description: Specify configuration like startup flags just for
+                      the MonitoringAgent. These take precedence over the flags set
+                      in AutomationAgent
                     properties:
                       logLevel:
                         type: string

--- a/charts/enterprise-operator/values-openshift.yaml
+++ b/charts/enterprise-operator/values-openshift.yaml
@@ -15,7 +15,7 @@ operator:
   operator_image_name: mongodb-enterprise-operator-ubi
 
   # Version of mongodb-enterprise-operator
-  version: 1.21.0
+  version: 1.22.0
 
   # The Custom Resources that will be watched by the Operator. Needs to be changed if only some of the CRDs are installed
   watchedResources:
@@ -45,7 +45,7 @@ database:
 
 initDatabase:
   name: mongodb-enterprise-init-database-ubi
-  version: 1.0.18
+  version: 1.0.19
 
 ## Ops Manager
 opsManager:
@@ -129,6 +129,7 @@ relatedImages:
   - 6.0.15
   - 6.0.16
   - 6.0.17
+  - 6.0.18
   mongodb:
   - 4.4.0-ubi8
   - 4.4.1-ubi8

--- a/charts/enterprise-operator/values.yaml
+++ b/charts/enterprise-operator/values.yaml
@@ -18,7 +18,7 @@ operator:
   deployment_name: mongodb-enterprise-operator
 
   # Version of mongodb-enterprise-operator
-  version: 1.21.0
+  version: 1.22.0
 
   # The Custom Resources that will be watched by the Operator. Needs to be changed if only some of the CRDs are installed
   watchedResources:
@@ -58,7 +58,7 @@ database:
 
 initDatabase:
   name: mongodb-enterprise-init-database-ubi
-  version: 1.0.18
+  version: 1.0.19
 
 ## Ops Manager
 opsManager:


### PR DESCRIPTION
## Kubernetes Enterprise Operator Release 1.22.0


This release patch has been created and it should be reviewed now.


You can add new commits to this patch if needed. After changes have
been reviewed, merge this PR for PCT to continue the release process.