### PR TITLE
CLOUDP-205250: Fix release double execution

### DIFF
--- a/.github/actions/releaser/action.yml
+++ b/.github/actions/releaser/action.yml
@@ -4,7 +4,7 @@ inputs:
   version:
     description: "The chart-releaser version to use (default: v1.2.1)"
     required: false
-    default: v1.2.1
+    default: v1.6.0
   charts_dir:
     description: "The charts directory"
     required: false

--- a/.github/actions/releaser/cr.sh
+++ b/.github/actions/releaser/cr.sh
@@ -54,6 +54,7 @@ release_charts_inside_folders() {
 
     # continue only with changed charts
     if [[ -n "${changed_charts[*]}" ]]; then
+        helm repo update
         install_chart_releaser
         cleanup_releaser
         package_charts "${changed_charts[@]}"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
 
       - name: Configure Git
         run: |
@@ -32,7 +32,7 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@v1
         with:
-          version: v3.4.0
+          version: v3.13.1
 
       - name: Add Helm repos
         run: |


### PR DESCRIPTION
### All Submissions:

* [x] Have you opened an Issue before filing this PR?
* [ ] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).

If I got it right, the job failed the first time because the CRD chart was released successfully but the operator, who depends on the new release, could not get it because the repo is outdated. In the second execution, the repo is already updated (aware of the newly released CRD) and the operator release works successfully. Updating the repo before releasing it chart should fix the problem.