### PR TITLE
Add support for operatorNamespaceManaged in values.yaml

### DIFF
--- a/charts/atlas-operator-crds/Chart.yaml
+++ b/charts/atlas-operator-crds/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: mongodb-atlas-operator-crds
 description: MongoDB Atlas Operator CRDs - Helm chart for installing and upgrading Custom Resource Definitions (CRDs) for the Atlas Operator.
 type: application
-version: 1.9.0
-appVersion: 1.9.0
+version: 1.10.0
+appVersion: 1.10.0
 kubeVersion: ">=1.15.0-0"
 keywords:
   - mongodb

--- a/charts/atlas-operator/Chart.yaml
+++ b/charts/atlas-operator/Chart.yaml
@@ -4,7 +4,7 @@ description: |-
   MongoDB Atlas Operator - a Helm chart for installing and upgrading Atlas Operator: the official Kubernetes operator allowing to manage MongoDB Atlas resources from Kubernetes
 type: application
 version: 1.10.0
-appVersion: 1.9.0
+appVersion: 1.10.0
 kubeVersion: ">=1.15.0-0"
 keywords:
   - mongodb
@@ -19,6 +19,6 @@ maintainers:
     email: support@mongodb.com
 dependencies:
   - name: mongodb-atlas-operator-crds
-    version: "1.9.0"
+    version: "1.10.0"
     repository: "https://mongodb.github.io/helm-charts"
     condition: mongodb-atlas-operator-crds.enabled

--- a/charts/atlas-operator/Chart.yaml
+++ b/charts/atlas-operator/Chart.yaml
@@ -3,7 +3,7 @@ name: mongodb-atlas-operator
 description: |-
   MongoDB Atlas Operator - a Helm chart for installing and upgrading Atlas Operator: the official Kubernetes operator allowing to manage MongoDB Atlas resources from Kubernetes
 type: application
-version: 1.9.0
+version: 1.10.0
 appVersion: 1.9.0
 kubeVersion: ">=1.15.0-0"
 keywords:

--- a/charts/atlas-operator/templates/roles.yaml
+++ b/charts/atlas-operator/templates/roles.yaml
@@ -1,16 +1,20 @@
 {{- $operatorName := include "mongodb-atlas-operator.name" . -}}
 {{- $serviceAccountName := include "mongodb-atlas-operator.serviceAccountName" . -}}
-{{- $operatorNamespaceManaged := has .Release.Namespace .Values.watchNamespaces -}}
+{{- fail ".Values.operatorNamespaceManaged and .Values.watchNamespaces cannot be configured at the same time" -}}
 
 {{- /* so far we support only a single namespace but otherwise should iterate over the watchNamespaces */}}
-{{- if .Values.watchNamespaces }}
+{{- if or .Values.operatorNamespaceManaged .Values.watchNamespaces }}
 {{- range $namespace := .Values.watchNamespaces }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: "{{ $operatorName }}"
+  {{- if .Values.operatorNamespaceManaged }}
+  namespace: {{ .Release.Namespace }}
+  {{- else }}
   namespace: {{ $namespace }}
+  {{- end }}
   labels:
   {{- include "mongodb-atlas-operator.labels" $ | nindent 4 }}
 rules:
@@ -20,7 +24,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: "{{ $operatorName }}"
+  {{- if .Values.operatorNamespaceManaged }}
+  namespace: {{ .Release.Namespace }}
+  {{- else }}
   namespace: {{ $namespace }}
+  {{- end }}
   labels:
   {{- include "mongodb-atlas-operator.labels" $ | nindent 4 }}
 roleRef:

--- a/charts/atlas-operator/values.yaml
+++ b/charts/atlas-operator/values.yaml
@@ -39,8 +39,11 @@ globalConnectionSecret:
 #
 # The only possible values are:
 # - empty (watch all namespaces) or
-# - the name of the same namespace where the Operator is installed to.
+# - a set of specific namespaces which are watched by the Operator.
 watchNamespaces: []
+
+# When enabled, the Operator can only manage the namespace where it is installed in.
+operatorNamespaceManaged: false
 
 # Use these values to use a different Operator image.
 image:


### PR DESCRIPTION
### All Submissions:

Adds operatorNamespaceManaged option to values.yaml so namespace doesn't have to be configured in watchNamespaces when doing a single namespace install.

* [] Have you opened an Issue before filing this PR?
* [x] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
