### PR TITLE
Skip broken helm chart version 1.9.1

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -1142,35 +1142,6 @@ entries:
     - https://github.com/mongodb/helm-charts/releases/download/mongodb-atlas-operator-1.9.2/mongodb-atlas-operator-1.9.2.tgz
     version: 1.9.2
   - apiVersion: v2
-    appVersion: 1.9.1
-    created: "2023-10-26T13:29:22.629810294Z"
-    dependencies:
-    - condition: mongodb-atlas-operator-crds.enabled
-      name: mongodb-atlas-operator-crds
-      repository: https://mongodb.github.io/helm-charts
-      version: 1.9.1
-    description: 'MongoDB Atlas Operator - a Helm chart for installing and upgrading
-      Atlas Operator: the official Kubernetes operator allowing to manage MongoDB
-      Atlas resources from Kubernetes'
-    digest: 31e72efa4db685a4ad1dc82b58166fdc544d85b60d4c5d6098cb8e95444127b0
-    home: https://github.com/mongodb/mongodb-atlas-kubernetes
-    icon: https://camo.githubusercontent.com/d473c25e361fb2206f06bdcf24028e8d52bc30d1/68747470733a2f2f6d6f6e676f64622d6b756265726e657465732d6f70657261746f722e73332e616d617a6f6e6177732e636f6d2f696d672f4c6561662d466f7265737425343032782e706e67
-    keywords:
-    - mongodb
-    - atlas
-    - database
-    - cluster
-    - nosql
-    kubeVersion: '>=1.15.0-0'
-    maintainers:
-    - email: support@mongodb.com
-      name: MongoDB
-    name: mongodb-atlas-operator
-    type: application
-    urls:
-    - https://github.com/mongodb/helm-charts/releases/download/mongodb-atlas-operator-1.9.1/mongodb-atlas-operator-1.9.1.tgz
-    version: 1.9.1
-  - apiVersion: v2
     appVersion: 1.9.0
     created: "2023-10-09T13:33:41.223445207Z"
     dependencies:


### PR DESCRIPTION
This should avoid people from downloading the broken 1.9.1 version of the Atlas Operator Helm Chart.

### All Submissions:

* [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
