### PR TITLE
Update community-operator chart to support having a namespace override

### DIFF
--- a/charts/community-operator/templates/database_roles.yaml
+++ b/charts/community-operator/templates/database_roles.yaml
@@ -3,14 +3,14 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ .Values.database.name }}
-  namespace: {{ if .Values.database.namespace }} {{ .Values.database.namespace }} {{ else }} {{ .Release.Namespace }} {{ end }}
+  namespace: {{ if .Values.database.namespace }} {{ .Values.database.namespace }} {{ else }} {{ default .Release.Namespace .Values.operator.namespaceOverride | trunc 63 | trimSuffix "-" }} {{ end }}
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ .Values.database.name }}
-  namespace: {{ if .Values.database.namespace }} {{ .Values.database.namespace }} {{ else }} {{ .Release.Namespace }} {{ end }}
+  namespace: {{ if .Values.database.namespace }} {{ .Values.database.namespace }} {{ else }} {{ default .Release.Namespace .Values.operator.namespaceOverride | trunc 63 | trimSuffix "-" }} {{ end }}
 rules:
   - apiGroups:
       - ""
@@ -32,7 +32,7 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ .Values.database.name }}
-  namespace: {{ if .Values.database.namespace }} {{ .Values.database.namespace }} {{ else }} {{ .Release.Namespace }} {{ end }}
+  namespace: {{ if .Values.database.namespace }} {{ .Values.database.namespace }} {{ else }} {{ default .Release.Namespace .Values.operator.namespaceOverride | trunc 63 | trimSuffix "-" }} {{ end }}
 subjects:
   - kind: ServiceAccount
     name: {{ .Values.database.name }}

--- a/charts/community-operator/templates/operator.yaml
+++ b/charts/community-operator/templates/operator.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     owner: mongodb
   name: {{ .Values.operator.name }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.operator.namespaceOverride | trunc 63 | trimSuffix "-" }}
 spec:
   replicas:  {{ .Values.operator.replicas }}
   selector:

--- a/charts/community-operator/templates/operator_namespace.yaml
+++ b/charts/community-operator/templates/operator_namespace.yaml
@@ -1,0 +1,6 @@
+{{- if .Values.operator.namespaceOverride }}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Values.operator.namespaceOverride }}
+{{- end }}

--- a/charts/community-operator/templates/operator_roles.yaml
+++ b/charts/community-operator/templates/operator_roles.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ .Values.operator.name }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.operator.namespaceOverride | trunc 63 | trimSuffix "-" }}
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -13,7 +13,7 @@ metadata:
   {{- if not (eq (.Values.operator.watchNamespace | default "*") "*") }}
   namespace: {{ .Values.operator.watchNamespace }}
   {{- else }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.operator.namespaceOverride | trunc 63 | trimSuffix "-" }}
   {{- end }}
 rules:
 - apiGroups:
@@ -65,12 +65,12 @@ metadata:
   {{- if ne (.Values.operator.watchNamespace | default "*") "*" }}
   namespace: {{ .Values.operator.watchNamespace }}
   {{- else }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.operator.namespaceOverride | trunc 63 | trimSuffix "-" }}
   {{- end }}
 subjects:
 - kind: ServiceAccount
   name: {{ .Values.operator.name }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace .Values.operator.namespaceOverride | trunc 63 | trimSuffix "-" }}
 roleRef:
   kind: {{ if eq (.Values.operator.watchNamespace | default "") "*" }} ClusterRole {{ else }} Role {{ end }}
   name: {{ .Values.operator.name }}

--- a/charts/community-operator/values.yaml
+++ b/charts/community-operator/values.yaml
@@ -10,7 +10,7 @@ operator:
 
   # Allow the operator namespace to be overridden which is useful when having this operator
   # be a subchart dependency
-  # namespaceOverride:
+  #namespaceOverride: mongodb-solution
 
   # Name of the operator image
   operatorImageName: mongodb-kubernetes-operator

--- a/charts/community-operator/values.yaml
+++ b/charts/community-operator/values.yaml
@@ -8,6 +8,10 @@ operator:
   # Deployment, ServiceAccount, Role etc.
   name: mongodb-kubernetes-operator
 
+  # Allow the operator namespace to be overridden which is useful when having this operator
+  # be a subchart dependency
+  # namespaceOverride:
+
   # Name of the operator image
   operatorImageName: mongodb-kubernetes-operator
 


### PR DESCRIPTION
Closes #276

We are building a top level "solution" helm chart that has several subchart dependencies, the community-operator helm chart being one.  We want to have the subchart be installed within a specific namespace that we can specify in the top level solution chart.  

Currently the community-operator helm chart has its namespace set to the Release namespace.  This pull request updates the templates such that an "operator.namespaceOverride" value can be set which then installs the chart into that namespace.  The proper namespaces for the database and service accounts are also configured if that value is set unless they are explicity set to something else such as the service account database namespace.

This has been tested as
* a standalone installation of the chart with no namespace override
* a standalone installation of the chart with **operator.namespaceOverride** set
* a subchart with no namespace override
* a subchart with **operator.namespaceOverride** set

When the **operator.namespaceOverride** is not set, there are no changes to the existing functionality.

### All Submissions:

* [x] Have you opened an Issue before filing this PR?
* [x] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
