### PR TITLE
CLOUDP-218696: Allow targeted helm chart releases

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,9 +1,5 @@
-# This is a basic workflow to help you get started with Actions
-
 name: Release Charts
 
-# Controls when the action will run. Triggers the workflow on push or pull request
-# events but only for the main branch
 on:
   push:
     branches:
@@ -11,15 +7,16 @@ on:
     paths-ignore:
       - '.github/**'
   workflow_dispatch:
+    inputs:
+      target:
+        description: "target chart to release"
+        type: string
+        default: ""
+        required: false
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "build"
   build:
-    # The type of runner that the job will run on
     runs-on: ubuntu-latest
-
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -44,6 +41,7 @@ jobs:
 
       - name: Helm Chart Dependency Releaser
         uses: ./.github/actions/releaser
+        if: github.event.inputs.target == ''
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
@@ -62,3 +60,4 @@ jobs:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           charts_repo_url: https://mongodb.github.io/helm-charts
+          target: ${{ github.event.inputs.target }}


### PR DESCRIPTION
Helps with stuck releases:
✅ [Released Helm chart for atlas-operator](https://github.com/mongodb/helm-charts/actions/runs/7261333698/job/19782300327)

### All Submissions:

* [X] Have you opened an Issue before filing this PR?
