### PR TITLE
CLOUDP-218696: Check chart was actually released

### DIFF
--- a/.github/actions/releaser/action.yml
+++ b/.github/actions/releaser/action.yml
@@ -15,6 +15,9 @@ inputs:
   target:
     description: "Specific charts folder inside <charts_dir> for releasing"
     required: false
+  dryrun:
+    description: "not actually release, but check what would be done"
+    required: false
 
 runs:
   using: composite
@@ -24,6 +27,7 @@ runs:
         export VERSION="${{ inputs.version }}"
         export CHART_DIR="${{ inputs.charts_dir }}"
         export CHARTS_REPO_URL="${{ inputs.charts_repo_url }}"
+        export DRYRUN="${{ inputs.dryrun }}"
 
         owner=$(cut -d '/' -f 1 <<< "$GITHUB_REPOSITORY")
         repo=$(cut -d '/' -f 2 <<< "$GITHUB_REPOSITORY")

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,6 +13,11 @@ on:
         type: string
         default: ""
         required: false
+      dryrun:
+        description: "not actually release, but check what would be done"
+        type: boolean
+        default: true
+        required: false
 
 jobs:
   build:
@@ -49,6 +54,7 @@ jobs:
           target: |
             atlas-operator-crds
             community-operator-crds
+          dryrun: ${{ github.event.inputs.dryrun }}
 
       - name: Get latest charts from repo
         run: |
@@ -61,3 +67,4 @@ jobs:
         with:
           charts_repo_url: https://mongodb.github.io/helm-charts
           target: ${{ github.event.inputs.target }}
+          dryrun: ${{ github.event.inputs.dryrun }}


### PR DESCRIPTION
Prior logic was checking git tags, which did not seem reliable at times and checks the wrong thing: we do not care as much for the tag to be present in git as for the actual helm chart with the given version to be present in the target helm chart repo.

This change searchs the repo for the expected chart version to check whether it was released or not, before checkign for changes in the chart.

✅ [DRYRUN did not find anything to do after release](https://github.com/mongodb/helm-charts/actions/runs/7264062651)

### All Submissions:

* [X] Have you opened an Issue before filing this PR?
