### PR TITLE
CLOUDP-218697: Detect helm chart releases happened

### DIFF
--- a/.github/workflows/check-released.yml
+++ b/.github/workflows/check-released.yml
@@ -1,0 +1,46 @@
+name: Check Released Charts
+
+on:
+  schedule:
+  - cron: "0 0 * * 1-5" # check-releases daily on work days
+  workflow_dispatch:
+    inputs:
+      target:
+        description: "target chart to release"
+        type: string
+        default: ""
+        required: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Install Helm
+        uses: azure/setup-helm@v1
+        with:
+          version: v3.13.1
+
+      - name: Add Helm repos
+        run: |
+          helm repo add mongodb https://mongodb.github.io/helm-charts
+
+      - name: Allow script
+        run: |
+          chmod +x ./.github/actions/releaser/cr.sh
+
+      - name: Helm Chart Dryrun & Release check
+        uses: ./.github/actions/releaser
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        with:
+          dryrun: true
+          charts_repo_url: https://mongodb.github.io/helm-charts
+          target: ${{ github.event.inputs.target }}

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ private/
 *.tgz
 .DS_Store
 .idea
+.vscode
 *.iml
 
 # ignoring generated charts and chart locks


### PR DESCRIPTION
Added a self-check that the charts are actually released after the release action loop. I used this combined with the dry-run input to be able to run a check that is triggered from a workflow running daily on every work day.

This shall give us the following:
- Releases should fail synchronously if the release merge did not actually managed to put the latest chart version in the helm repo.
- Daily we double check what the source code says is the latest chart is available in the helm chart repo.

By default this is done for all helm charts in the repo.

✅ [Release checks using dryrun](https://github.com/mongodb/helm-charts/actions/runs/7278587589)

### All Submissions:

* [X] Have you opened an Issue before filing this PR?
