### PR TITLE
CLOUDP-218697: Fix get latest tag

### DIFF
--- a/.github/actions/releaser/cr.sh
+++ b/.github/actions/releaser/cr.sh
@@ -156,7 +156,7 @@ get_latest_tag(){
     local name=$1
 
     git fetch --tags > /dev/null 2>&1
-    git describe --tags --abbrev=0 --match="$name-[0-9.]*" "$(git rev-list --tags --max-count=1)"
+    git tag -l --sort=-refname |grep "^$name-[0-9]*\." |head -1
 }
 
 release_changed_charts() {

--- a/.github/actions/releaser/cr.sh
+++ b/.github/actions/releaser/cr.sh
@@ -156,7 +156,7 @@ get_latest_tag(){
     local name=$1
 
     git fetch --tags > /dev/null 2>&1
-    git tag -l --sort=-refname |grep "^$name-[0-9]*\." |head -1
+    git tag -l --sort=-refname |grep "^$name-[0-9]*\." | head -1
 }
 
 release_changed_charts() {


### PR DESCRIPTION
The `bash` function `get_latest_tag` was failing in some cases, detecting older tags as the latest. 

This fix changes the way the latest tag is computed so we always get correct results.

✅ [Release charts dryrun detects NO skews between latest released chart and latest tag](https://github.com/mongodb/helm-charts/actions/runs/7395670295/job/20119272739)


### All Submissions:

* [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
