### PR TITLE
CLOUDP-227025: Reapply add support for deletion protection flags

### DIFF
--- a/charts/atlas-operator/templates/deployment.yaml
+++ b/charts/atlas-operator/templates/deployment.yaml
@@ -32,6 +32,8 @@ spec:
             - --atlas-domain={{ .Values.atlasURI }}
             - "--health-probe-bind-address=:8081"
             - "--metrics-bind-address=:8080"
+            - --object-deletion-protection={{ .Values.objectDeletionProtection }}
+            - --subobject-deletion-protection={{ .Values.subobjectDeletionProtection }}
             - "--leader-elect"
           command:
             - /manager

--- a/charts/atlas-operator/values.yaml
+++ b/charts/atlas-operator/values.yaml
@@ -18,6 +18,11 @@ mongodb-atlas-operator-crds:
 # atlasURI is the URI of the MongoDB Atlas. You should not change this value.
 atlasURI: https://cloud.mongodb.com/
 
+# objectDeletionProtection defines the operator will not delete Atlas resource when a Custom Resource is deleted
+objectDeletionProtection: true
+# subobjectDeletionProtection defines that the operator will not overwrite (and consequently delete) subresources that were not previously created by the operator
+subobjectDeletionProtection: true
+
 # globalConnectionSecret is a default "global" Secret containing Atlas
 # authentication information.
 #


### PR DESCRIPTION
Re-applies: https://github.com/mongodb/helm-charts/commit/12f59b02590a3f6421d244fb4a59fd5a9ae1390e
To undo: https://github.com/mongodb/helm-charts/commit/cdb9c35dcd41208ec89cc08e96c198eb578d2024

This re-enables the possibility of configuring deletion protection in the Helm chart.

### All Submissions:

* [x] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
