### PR TITLE
CLOUDP-226369: Allow backport releases

### DIFF
--- a/.github/actions/releaser/action.yml
+++ b/.github/actions/releaser/action.yml
@@ -5,10 +5,10 @@ inputs:
     description: "The chart-releaser version to use (default: v1.2.1)"
     required: false
     default: v1.6.0
-  charts_dir:
-    description: "The charts directory"
+  work_dir:
+    description: "The repo directory"
     required: false
-    default: charts
+    default: "."
   charts_repo_url:
     description: "The GitHub Pages URL to the charts repo (default: https://<owner>.github.io/<repo>)"
     required: true
@@ -18,6 +18,10 @@ inputs:
   dryrun:
     description: "not actually release, but check what would be done"
     required: false
+  mark_latest:
+    description: "mark released charts as latest"
+    required: false
+    default: "true"
 
 runs:
   using: composite
@@ -25,13 +29,15 @@ runs:
     - shell: bash
       run: |
         export VERSION="${{ inputs.version }}"
-        export CHART_DIR="${{ inputs.charts_dir }}"
+        export WORK_DIR=${{ inputs.work_dir }}
+        export CHART_DIR="charts"
         export CHARTS_REPO_URL="${{ inputs.charts_repo_url }}"
         export DRYRUN="${{ inputs.dryrun }}"
+        export MARK_LATEST="${{ inputs.mark_latest }}"
 
         owner=$(cut -d '/' -f 1 <<< "$GITHUB_REPOSITORY")
         repo=$(cut -d '/' -f 2 <<< "$GITHUB_REPOSITORY")
         export OWNER=$owner
         export REPO=$repo
 
-        "$GITHUB_ACTION_PATH/cr.sh" "${{ inputs.target }}"
+        cd $WORK_DIR && "$GITHUB_ACTION_PATH/cr.sh" "${{ inputs.target }}"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,20 +14,45 @@ on:
         default: ""
         required: false
       dryrun:
-        description: "not actually release, but check what would be done"
+        description: "dry-run"
         type: boolean
         default: true
+        required: false
+      backport-branch:
+        description: "Branch or leave empty for current CI branch"
+        type: string
+        default: ""
         required: false
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      BACKPORT_BRANCH: ${{ github.event.inputs.backport-branch || '' }}
+      BACKPORT_DIR: 'backport'
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          path: current
+
+      - name: Checkout Backport branch
+        uses: actions/checkout@v4
+        if: github.event.inputs.backport-branch != ''
+        with:
+          ref: ${{ env.BACKPORT_BRANCH }}
+          path: ${{ env.BACKPORT_DIR }}
 
       - name: Configure Git
         run: |
+          cd current
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Configure Git for backport
+        if: github.event.inputs.backport-branch != ''
+        run: |
+          cd ${{ env.BACKPORT_DIR }}
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
@@ -42,10 +67,10 @@ jobs:
 
       - name: Allow script
         run: |
-          chmod +x ./.github/actions/releaser/cr.sh
+          chmod +x ./current/.github/actions/releaser/cr.sh
 
       - name: Helm Chart Dependency Releaser
-        uses: ./.github/actions/releaser
+        uses: ./current/.github/actions/releaser
         if: github.event.inputs.target == ''
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
@@ -55,16 +80,21 @@ jobs:
             atlas-operator-crds
             community-operator-crds
           dryrun: ${{ github.event.inputs.dryrun }}
+          work_dir: current
 
       - name: Get latest charts from repo
         run: |
           helm repo update
 
       - name: Helm Chart Releaser
-        uses: ./.github/actions/releaser
+        uses: ./current/.github/actions/releaser
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          WORK_DIR: ${{ github.event.inputs.backport-branch == '' && 'current' || env.BACKPORT_DIR }}
+          MARK_LATEST: ${{ github.event.inputs.backport-branch == '' && 'true' || 'false' }}
         with:
           charts_repo_url: https://mongodb.github.io/helm-charts
           target: ${{ github.event.inputs.target }}
           dryrun: ${{ github.event.inputs.dryrun }}
+          work_dir: ${{ env.WORK_DIR }}
+          mark_latest: ${{ env.MARK_LATEST }}


### PR DESCRIPTION
- Allow to optionally checkout a back-port branch next to the CI selected branch (current).
- Change the working directory base to current, or `backport` when doing a back-port.
- Mark chart as NOT latest when doing a back-port.

**Tests**

✅ [DRYRUN release atlas-operator-crds](https://github.com/mongodb/helm-charts/actions/runs/7796002104/job/21259885846)

🟠 [Managed to release CRDs Helm chart](https://github.com/mongodb/helm-charts/actions/runs/7797488632/job/21264186528) but did not detect it was released properly.
- ✅ [Re-run did nothing as it was released](https://github.com/mongodb/helm-charts/actions/runs/7798278649)

✅ [Regular periodic run does nothing, all charts are already released (keeps working)](https://github.com/mongodb/helm-charts/actions/runs/7798784432/job/21268180080)

🟠 [Managed to release the main Helm Chart](https://github.com/mongodb/helm-charts/actions/runs/7798871970) but it did not detect it as releases properly.
-  ✅ [Rerun notices it was released](https://github.com/mongodb/helm-charts/actions/runs/7798904483/job/21268542744)

### All Submissions:

* [x] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
