### PR TITLE
Kubernetes Enterprise Operator Release 1.25.0

### DIFF
--- a/charts/enterprise-operator/Chart.yaml
+++ b/charts/enterprise-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: enterprise-operator
 description: MongoDB Kubernetes Enterprise Operator
-version: 1.24.0
+version: 1.25.0
 kubeVersion: '>=1.16-0'
 type: application
 keywords:

--- a/charts/enterprise-operator/crds/mongodb.com_mongodb.yaml
+++ b/charts/enterprise-operator/crds/mongodb.com_mongodb.yaml
@@ -875,7 +875,7 @@ spec:
                 type: array
               statefulSet:
                 description: StatefulSetConfiguration provides the statefulset override
-                  for each of the cluster's statefulset if  "StatefulSetConfiguration"
+                  for each of the cluster's statefulset if "StatefulSetConfiguration"
                   is specified at cluster level under "clusterSpecList" that takes
                   precedence over the global one
                 properties:

--- a/charts/enterprise-operator/crds/mongodb.com_mongodbmulticluster.yaml
+++ b/charts/enterprise-operator/crds/mongodb.com_mongodbmulticluster.yaml
@@ -614,7 +614,7 @@ spec:
                 type: object
               statefulSet:
                 description: StatefulSetConfiguration provides the statefulset override
-                  for each of the cluster's statefulset if  "StatefulSetConfiguration"
+                  for each of the cluster's statefulset if "StatefulSetConfiguration"
                   is specified at cluster level under "clusterSpecList" that takes
                   precedence over the global one
                 properties:

--- a/charts/enterprise-operator/crds/mongodb.com_opsmanagers.yaml
+++ b/charts/enterprise-operator/crds/mongodb.com_opsmanagers.yaml
@@ -194,8 +194,16 @@ spec:
                           - name
                           type: object
                         type: array
-                    required:
-                    - processes
+                      replicaSet:
+                        properties:
+                          settings:
+                            description: MapWrapper is a wrapper for a map to be used
+                              by other structs. The CRD generator does not support
+                              map[string]interface{} on the top level and hence we
+                              need to work around this with a wrapping struct.
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                        type: object
                     type: object
                   cloudManager:
                     properties:
@@ -1070,6 +1078,180 @@ spec:
                   which should be used instead'
                 format: hostname
                 type: string
+              clusterSpecList:
+                items:
+                  description: ClusterSpecOMItem defines members cluster details for
+                    Ops Manager multi-cluster deployment.
+                  properties:
+                    backup:
+                      description: Backup contains settings to override from top-level
+                        `spec.backup` for this member cluster. If the value is not
+                        set here, then the value is taken from `spec.backup`.
+                      properties:
+                        assignmentLabels:
+                          description: Assignment Labels set in the Ops Manager
+                          items:
+                            type: string
+                          type: array
+                        headDB:
+                          description: HeadDB specifies configuration options for
+                            the HeadDB
+                          properties:
+                            labelSelector:
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
+                            storage:
+                              type: string
+                            storageClass:
+                              type: string
+                          type: object
+                        jvmParameters:
+                          items:
+                            type: string
+                          type: array
+                        members:
+                          description: Members indicate the number of backup daemon
+                            pods to create.
+                          minimum: 0
+                          type: integer
+                        statefulSet:
+                          description: StatefulSetConfiguration specified optional
+                            overrides for backup datemon statefulset.
+                          properties:
+                            metadata:
+                              description: StatefulSetMetadataWrapper is a wrapper
+                                around Labels and Annotations
+                              properties:
+                                annotations:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                labels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              type: object
+                            spec:
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
+                          required:
+                          - spec
+                          type: object
+                      type: object
+                    clusterDomain:
+                      description: Cluster domain to override the default *.svc.cluster.local
+                        if the default cluster domain has been changed on a cluster
+                        level.
+                      format: hostname
+                      type: string
+                    clusterName:
+                      description: ClusterName is name of the cluster where the Ops
+                        Manager Statefulset will be scheduled. The operator is using
+                        ClusterName to find API credentials in `mongodb-enterprise-operator-member-list`
+                        config map to use for this member cluster. If the credentials
+                        are not found, then the member cluster is considered unreachable
+                        and ignored in the reconcile process.
+                      type: string
+                    configuration:
+                      additionalProperties:
+                        type: string
+                      description: The configuration properties passed to Ops Manager
+                        and Backup Daemon in this cluster. If specified (not empty)
+                        then this field overrides `spec.configuration` field entirely.
+                        If not specified, then `spec.configuration` field is used
+                        for the Ops Manager and Backup Daemon instances in this cluster.
+                      type: object
+                    externalConnectivity:
+                      description: MongoDBOpsManagerExternalConnectivity if sets allows
+                        for the creation of a Service for accessing Ops Manager instances
+                        in this member cluster from outside the Kubernetes cluster.
+                        If specified (even if provided empty) then this field overrides
+                        `spec.externalConnectivity` field entirely. If not specified,
+                        then `spec.externalConnectivity` field is used for the Ops
+                        Manager and Backup Daemon instances in this cluster.
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: Annotations is a list of annotations to be
+                            directly passed to the Service object.
+                          type: object
+                        clusterIP:
+                          description: ClusterIP IP that will be assigned to this
+                            Service when creating a ClusterIP type Service
+                          type: string
+                        externalTrafficPolicy:
+                          description: ExternalTrafficPolicy mechanism to preserve
+                            the client source IP. Only supported on GCE and Google
+                            Kubernetes Engine.
+                          enum:
+                          - Cluster
+                          - Local
+                          type: string
+                        loadBalancerIP:
+                          description: LoadBalancerIP IP that will be assigned to
+                            this LoadBalancer.
+                          type: string
+                        port:
+                          description: Port in which this `Service` will listen to,
+                            this applies to `NodePort`.
+                          format: int32
+                          type: integer
+                        type:
+                          description: Type of the `Service` to be created.
+                          enum:
+                          - LoadBalancer
+                          - NodePort
+                          - ClusterIP
+                          type: string
+                      required:
+                      - type
+                      type: object
+                    jvmParameters:
+                      description: JVM parameters to pass to Ops Manager and Backup
+                        Daemon instances in this member cluster. If specified (not
+                        empty) then this field overrides `spec.jvmParameters` field
+                        entirely. If not specified, then `spec.jvmParameters` field
+                        is used for the Ops Manager and Backup Daemon instances in
+                        this cluster.
+                      items:
+                        type: string
+                      type: array
+                    members:
+                      description: Number of Ops Manager instances in this member
+                        cluster.
+                      type: integer
+                    statefulSet:
+                      description: Configure custom StatefulSet configuration to override
+                        in Ops Manager's statefulset in this member cluster. If specified
+                        (even if provided empty) then this field overrides `spec.externalConnectivity`
+                        field entirely. If not specified, then `spec.externalConnectivity`
+                        field is used for the Ops Manager and Backup Daemon instances
+                        in this cluster.
+                      properties:
+                        metadata:
+                          description: StatefulSetMetadataWrapper is a wrapper around
+                            Labels and Annotations
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            labels:
+                              additionalProperties:
+                                type: string
+                              type: object
+                          type: object
+                        spec:
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
+                      required:
+                      - spec
+                      type: object
+                  required:
+                  - members
+                  type: object
+                type: array
               configuration:
                 additionalProperties:
                   type: string
@@ -1087,6 +1269,10 @@ spec:
                     description: Annotations is a list of annotations to be directly
                       passed to the Service object.
                     type: object
+                  clusterIP:
+                    description: ClusterIP IP that will be assigned to this Service
+                      when creating a ClusterIP type Service
+                    type: string
                   externalTrafficPolicy:
                     description: ExternalTrafficPolicy mechanism to preserve the client
                       source IP. Only supported on GCE and Google Kubernetes Engine.
@@ -1107,6 +1293,47 @@ spec:
                     enum:
                     - LoadBalancer
                     - NodePort
+                    - ClusterIP
+                    type: string
+                required:
+                - type
+                type: object
+              internalConnectivity:
+                description: InternalConnectivity if set allows for overriding the
+                  settings of the default service used for internal connectivity to
+                  the OpsManager servers.
+                properties:
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    description: Annotations is a list of annotations to be directly
+                      passed to the Service object.
+                    type: object
+                  clusterIP:
+                    description: ClusterIP IP that will be assigned to this Service
+                      when creating a ClusterIP type Service
+                    type: string
+                  externalTrafficPolicy:
+                    description: ExternalTrafficPolicy mechanism to preserve the client
+                      source IP. Only supported on GCE and Google Kubernetes Engine.
+                    enum:
+                    - Cluster
+                    - Local
+                    type: string
+                  loadBalancerIP:
+                    description: LoadBalancerIP IP that will be assigned to this LoadBalancer.
+                    type: string
+                  port:
+                    description: Port in which this `Service` will listen to, this
+                      applies to `NodePort`.
+                    format: int32
+                    type: integer
+                  type:
+                    description: Type of the `Service` to be created.
+                    enum:
+                    - LoadBalancer
+                    - NodePort
+                    - ClusterIP
                     type: string
                 required:
                 - type
@@ -1116,6 +1343,17 @@ spec:
                 items:
                   type: string
                 type: array
+              opsManagerURL:
+                description: OpsManagerURL specified the URL with which the operator
+                  and AppDB monitoring agent should access Ops Manager instance (or
+                  instances). When not set, the operator is using FQDN of Ops Manager's
+                  headless service `{name}-svc.{namespace}.svc.cluster.local` to connect
+                  to the instance. If that URL cannot be used, then URL in this field
+                  should be provided for the operator to connect to Ops Manager instances.
+                  It defaults (and if not set) to SingleCluster. If MultiCluster specified,
+                  then clusterSpecList field is mandatory and at least one member
+                  cluster has to be specified.
+                type: string
               replicas:
                 minimum: 1
                 type: integer
@@ -1159,6 +1397,15 @@ spec:
                 required:
                 - spec
                 type: object
+              topology:
+                description: Topology sets the desired cluster topology of Ops Manager
+                  deployment. It defaults (and if not set) to SingleCluster. If MultiCluster
+                  specified, then clusterSpecList field is mandatory and at least
+                  one member cluster has to be specified.
+                enum:
+                - SingleCluster
+                - MultiCluster
+                type: string
               version:
                 type: string
             required:
@@ -1176,6 +1423,15 @@ spec:
                     required:
                     - statusName
                     type: object
+                  clusterStatusList:
+                    items:
+                      properties:
+                        clusterName:
+                          type: string
+                        members:
+                          type: integer
+                      type: object
+                    type: array
                   configServerCount:
                     type: integer
                   lastTransition:
@@ -1236,6 +1492,15 @@ spec:
                 type: object
               backup:
                 properties:
+                  clusterStatusList:
+                    items:
+                      properties:
+                        clusterName:
+                          type: string
+                        replicas:
+                          type: integer
+                      type: object
+                    type: array
                   lastTransition:
                     type: string
                   message:
@@ -1283,6 +1548,15 @@ spec:
                 type: object
               opsManager:
                 properties:
+                  clusterStatusList:
+                    items:
+                      properties:
+                        clusterName:
+                          type: string
+                        replicas:
+                          type: integer
+                      type: object
+                    type: array
                   lastTransition:
                     type: string
                   message:

--- a/charts/enterprise-operator/templates/database-roles.yaml
+++ b/charts/enterprise-operator/templates/database-roles.yaml
@@ -1,3 +1,5 @@
+{{ if .Values.operator.createResourcesServiceAccountsAndRoles }}
+
 {{- $watchNamespace := include "mongodb-enterprise-operator.namespace" . | list }}
 {{- if .Values.operator.watchNamespace }}
 {{- $watchNamespace = regexSplit "," .Values.operator.watchNamespace -1 }}
@@ -81,3 +83,4 @@ subjects:
     {{ $namespaceBlock }}
 
 {{- end }}
+{{- end }}{{/* if .Values.operator.createResourcesServiceAccountsAndRoles */}}

--- a/charts/enterprise-operator/templates/operator-configmap.yaml
+++ b/charts/enterprise-operator/templates/operator-configmap.yaml
@@ -1,0 +1,17 @@
+{{ $ns :=  include "mongodb-enterprise-operator.namespace" .  -}}
+{{- if not (lookup "v1" "ConfigMap" $ns "mongodb-enterprise-operator-member-list") }}
+{{- if .Values.multiCluster.clusters }}
+---
+apiVersion: v1
+kind: ConfigMap
+data:
+  {{- range .Values.multiCluster.clusters }}
+  {{ . }}: ""
+  {{- end }}
+metadata:
+  namespace: {{$ns}}
+  name: mongodb-enterprise-operator-member-list
+  labels:
+    multi-cluster: "true"
+{{- end }}
+{{- end }}

--- a/charts/enterprise-operator/templates/operator-roles.yaml
+++ b/charts/enterprise-operator/templates/operator-roles.yaml
@@ -1,15 +1,4 @@
 {{ if .Values.operator.createOperatorServiceAccount }}
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: {{ .Values.operator.name }}
-  namespace: {{ include "mongodb-enterprise-operator.namespace" . }}
-{{- if .Values.registry.imagePullSecrets}}
-imagePullSecrets:
-  - name: {{ .Values.registry.imagePullSecrets }}
-{{- end }}
-
 {{- $watchNamespace := include "mongodb-enterprise-operator.namespace" . | list }}
 {{- if .Values.operator.watchNamespace }}
 {{- $watchNamespace = regexSplit "," .Values.operator.watchNamespace -1 }}
@@ -20,7 +9,6 @@ imagePullSecrets:
 {{- if or (gt (len $watchNamespace) 1) (eq (first $watchNamespace) "*") }}
 {{- $roleScope = "ClusterRole" }}
 {{- end }}
-
 ---
 kind: {{ $roleScope }}
 apiVersion: rbac.authorization.k8s.io/v1
@@ -82,6 +70,7 @@ rules:
       - mongodb
       - mongodb/finalizers
       - mongodbusers
+      - mongodbusers/finalizers
       - opsmanagers
       - opsmanagers/finalizers
       - mongodbmulticluster
@@ -127,15 +116,13 @@ subjects:
   - kind: ServiceAccount
     name: {{ $.Values.operator.name }}
     namespace: {{ include "mongodb-enterprise-operator.namespace" $ }}
-{{- end }}
+{{- end }} {{/* range */}}
 
-{{- end }}
-
-# This ClusterRoleBinding is necessary in order to use validating
-# webhooks—these will prevent you from applying a variety of invalid resource
-# definitions. The validating webhooks are optional so this can be removed if
-# necessary.
+{{- end }} {{/* if .Values.operator.createOperatorServiceAccount */}}
 ---
+
+{{/* This cluster role and binding is necessary to allow the operator to automatically register ValidatingWebhookConfiguration. */}}
+{{- if .Values.operator.webhook.registerConfiguration }}
 {{- if not (lookup "rbac.authorization.k8s.io/v1" "ClusterRole" "" "mongodb-enterprise-operator-mongodb-webhook") }}
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -162,7 +149,7 @@ rules:
       - create
       - update
       - delete
-{{- end }}
+{{- end }} {{/* if not (lookup ... */}}
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -176,3 +163,5 @@ subjects:
   - kind: ServiceAccount
     name: {{ .Values.operator.name }}
     namespace: {{ include "mongodb-enterprise-operator.namespace" . }}
+
+{{- end }} {{/* if .Values.operator.webhook.registerConfiguration */}}

--- a/charts/enterprise-operator/templates/operator-sa.yaml
+++ b/charts/enterprise-operator/templates/operator-sa.yaml
@@ -1,0 +1,23 @@
+{{ if .Values.operator.createOperatorServiceAccount }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.operator.name }}
+  namespace: {{ include "mongodb-enterprise-operator.namespace" . }}
+{{- if .Values.registry.imagePullSecrets}}
+imagePullSecrets:
+  - name: {{ .Values.registry.imagePullSecrets }}
+{{- end }}
+
+{{- $watchNamespace := include "mongodb-enterprise-operator.namespace" . | list }}
+{{- if .Values.operator.watchNamespace }}
+{{- $watchNamespace = regexSplit "," .Values.operator.watchNamespace -1 }}
+{{- $watchNamespace = concat $watchNamespace (include "mongodb-enterprise-operator.namespace" . | list) | uniq }}
+{{- end }}
+
+{{- $roleScope := "Role" -}}
+{{- if or (gt (len $watchNamespace) 1) (eq (first $watchNamespace) "*") }}
+{{- $roleScope = "ClusterRole" }}
+{{- end }}
+{{- end }} {{/* if .Values.operator.createOperatorServiceAccount */}}

--- a/charts/enterprise-operator/templates/operator.yaml
+++ b/charts/enterprise-operator/templates/operator.yaml
@@ -7,7 +7,7 @@ metadata:
   name: {{ .Values.operator.name }}
   namespace: {{$ns}}
 spec:
-  replicas: {{ .Values.operator.replicas }}
+  replicas: {{ min 1 .Values.operator.replicas }}
   selector:
     matchLabels:
       app.kubernetes.io/component: controller
@@ -50,8 +50,11 @@ spec:
             {{- range .Values.operator.watchedResources }}
             - -watch-resource={{ . }}
             {{- end }}
-          {{- if .Values.multiCluster.clusters }}
+            {{- if .Values.multiCluster.clusters }}
             - -watch-resource=mongodbmulticluster
+            {{- end }}
+            {{- range .Values.operator.additionalArguments }}
+            - {{ . }}
             {{- end }}
           command:
             - /usr/local/bin/mongodb-enterprise-operator
@@ -71,6 +74,8 @@ spec:
           env:
             - name: OPERATOR_ENV
               value: {{ .Values.operator.env }}
+            - name: MDB_DEFAULT_ARCHITECTURE
+              value: {{ .Values.operator.mdbDefaultArchitecture }}
     {{- if .Values.operator.vaultSecretBackend }}
       {{- if .Values.operator.vaultSecretBackend.enabled }}
             - name: SECRET_BACKEND
@@ -100,6 +105,7 @@ spec:
     {{- $mongodbEnterpriseDatabaseImageEnv := "MONGODB_ENTERPRISE_DATABASE_IMAGE" -}}
     {{- $initDatabaseImageRepositoryEnv := "INIT_DATABASE_IMAGE_REPOSITORY" -}}
     {{- $opsManagerImageRepositoryEnv := "OPS_MANAGER_IMAGE_REPOSITORY" -}}
+    {{- $agentImageRepository := "MDB_AGENT_IMAGE_REPOSITORY" -}}
     {{- $initOpsManagerImageRepositoryEnv := "INIT_OPS_MANAGER_IMAGE_REPOSITORY" -}}
     {{- $initAppDbImageRepositoryEnv := "INIT_APPDB_IMAGE_REPOSITORY" -}}
     {{- $agentImageEnv := "AGENT_IMAGE" -}}
@@ -135,7 +141,9 @@ spec:
             - name: OPS_MANAGER_IMAGE_PULL_POLICY
               value: {{ .Values.registry.pullPolicy }}
             - name: {{ $agentImageEnv }}
-              value: "{{ .Values.registry.agent }}/{{ .Values.agent.name }}:{{ $agentVersion }}"
+              value: "{{ $.Values.registry.agent }}/{{ $.Values.agent.name }}:{{ .Values.agent.version }}"
+            - name: {{ $agentImageRepository }}
+              value: "{{ $.Values.registry.agent }}/{{ $.Values.agent.name }}"
             - name: {{ $mongodbImageEnv }}
               value: {{ .Values.mongodb.name }}
             - name: MONGODB_REPO_URL
@@ -153,6 +161,10 @@ spec:
     {{- if .Values.registry.imagePullSecrets }}
             - name: IMAGE_PULL_SECRETS
               value: {{ .Values.registry.imagePullSecrets }}
+    {{- end }}
+    {{- if not .Values.operator.webhook.registerConfiguration }}
+            - name: MDB_WEBHOOK_REGISTER_CONFIGURATION
+              value: "false"
     {{- end }}
     {{- if .Values.relatedImages }}
             - name: RELATED_IMAGE_{{ $mongodbEnterpriseDatabaseImageEnv }}_{{ $databaseVersion | replace "." "_" | replace "-" "_" }}
@@ -211,35 +223,4 @@ spec:
   {{- end }}
 {{- end }}
 
-{{- if .Values.debug }}
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: debug-svc
-spec:
-  type: NodePort
-  ports:
-  - nodePort: {{ .Values.debugPort }}
-    port: 40000
-    protocol: TCP
-  selector:
-    app.kubernetes.io/name: {{ .Values.operator.name }}
-{{- end }}
 
-{{- if not (lookup "v1" "ConfigMap" $ns "mongodb-enterprise-operator-member-list") }}
-{{- if .Values.multiCluster.clusters }}
----
-apiVersion: v1
-kind: ConfigMap
-data:
-  {{- range .Values.multiCluster.clusters }}
-  {{ . | indent 1 }}: ""
-  {{- end }}
-metadata:
-  namespace: {{$ns}}
-  name: mongodb-enterprise-operator-member-list
-  labels:
-    multi-cluster: "true"
-{{- end }}
-{{- end }}

--- a/charts/enterprise-operator/values-multi-cluster.yaml
+++ b/charts/enterprise-operator/values-multi-cluster.yaml
@@ -22,7 +22,7 @@ operator:
   deployment_name: mongodb-enterprise-operator
 
   # Version of mongodb-enterprise-operator
-  version: 1.24.0
+  version: 1.25.0
 
   # The Custom Resources that will be watched by the Operator. Needs to be changed if only some of the CRDs are installed
   watchedResources:
@@ -58,11 +58,11 @@ operator:
 ## Database
 database:
   name: mongodb-enterprise-database-ubi
-  version: 1.24.0
+  version: 1.25.0
 
 initDatabase:
   name: mongodb-enterprise-init-database-ubi
-  version: 1.24.0
+  version: 1.25.0
 
 ## Ops Manager
 opsManager:
@@ -70,12 +70,12 @@ opsManager:
 
 initOpsManager:
   name: mongodb-enterprise-init-ops-manager-ubi
-  version: 1.24.0
+  version: 1.25.0
 
 ## Application Database
 initAppDb:
   name: mongodb-enterprise-init-appdb-ubi
-  version: 1.24.0
+  version: 1.25.0
 
 agent:
   name: mongodb-agent-ubi

--- a/charts/enterprise-operator/values-multi-cluster.yaml
+++ b/charts/enterprise-operator/values-multi-cluster.yaml
@@ -1,3 +1,5 @@
+## Operator
+
 # Set this to true if your cluster is managing SecurityContext for you.
 # If running OpenShift (Cloud, Minishift, etc.), set this to true.
 managedSecurityContext: false
@@ -11,7 +13,7 @@ operator:
   mdbDefaultArchitecture: non-static
 
   # Name that will be assigned to most internal Kubernetes objects like Deployment, ServiceAccount, Role etc.
-  name: mongodb-enterprise-operator
+  name: mongodb-enterprise-operator-multi-cluster
 
   # Name of the operator image
   operator_image_name: mongodb-enterprise-operator-ubi
@@ -20,13 +22,13 @@ operator:
   deployment_name: mongodb-enterprise-operator
 
   # Version of mongodb-enterprise-operator
-  version: 1.25.0
+  version: 1.24.0
 
   # The Custom Resources that will be watched by the Operator. Needs to be changed if only some of the CRDs are installed
   watchedResources:
-  - mongodb
-  - opsmanagers
-  - mongodbusers
+    - mongodb
+    - opsmanagers
+    - mongodbusers
 
   nodeSelector: {}
 
@@ -43,50 +45,24 @@ operator:
       cpu: 1100m
       memory: 1Gi
 
-  # Create operator service account and roles
-  # if false, then templates/operator-roles.yaml is excluded
+  # Create operator-service account
   createOperatorServiceAccount: true
-
-  # Set to false to NOT create service accounts and roles for the resources managed by the operator
-  # It might be necessary to disable it to avoid conflicts when
-  # kubectl mongodb plugin is used to configure multi-cluster resources
-  createResourcesServiceAccountsAndRoles: true
 
   vaultSecretBackend:
     # set to true if you want the operator to store secrets in Vault
     enabled: false
-    tlsSecretRef: ''
+    tlsSecretRef: ""
 
-  # 0 or 1 is supported only
   replicas: 1
-  # additional arguments to pass on the operator's binary arguments, e.g. operator.additionalArguments={--v=9} to dump debug k8s networking to logs
-  additionalArguments: []
-
-  webhook:
-    # registerConfiguration setting (default: true) controls if the operator should automatically register ValidatingWebhookConfiguration and if required for it cluster-wide roles should be installed.
-    #
-    # Setting false:
-    #  - Adds env var MDB_WEBHOOK_REGISTER_CONFIGURATION=false to the operator deployment.
-    #  - ClusterRole and ClusterRoleBinding required to manage ValidatingWebhookConfigurations will not be installed
-    #  - The operator will not create ValidatingWebhookConfigurations upon startup.
-    #  - The operator will not create the service for the webhook. If the `operator-webhook` service was created before, it will be deleted.
-    #  - The operator will still expose the webhook's endpoint on port on MDB_WEBHOOK_PORT (if not specified, the operator uses a default 1993) in case the ValidatingWebhookConfigurations is configured externally (e.g. in OLM/OpenShift) or by the administrator manually.
-    #
-    # Setting true:
-    #  - It's the default setting, behaviour of the operator w.r.t. webhook configuration is the same as before.
-    #  - operator-webhook service will be created by the operator
-    #  - ClusterRole and ClusterRoleBinding required to manage ValidatingWebhookConfigurations will be installed.
-    #  - ValidatingWebhookConfigurations will be managed by the operator (requires cluster permissions)
-    registerConfiguration: true
 
 ## Database
 database:
   name: mongodb-enterprise-database-ubi
-  version: 1.25.0
+  version: 1.24.0
 
 initDatabase:
   name: mongodb-enterprise-init-database-ubi
-  version: 1.25.0
+  version: 1.24.0
 
 ## Ops Manager
 opsManager:
@@ -94,16 +70,16 @@ opsManager:
 
 initOpsManager:
   name: mongodb-enterprise-init-ops-manager-ubi
-  version: 1.25.0
+  version: 1.24.0
 
 ## Application Database
 initAppDb:
   name: mongodb-enterprise-init-appdb-ubi
-  version: 1.25.0
+  version: 1.24.0
 
 agent:
   name: mongodb-agent-ubi
-  version: 107.0.0.8502-1
+  version: 12.0.29.7785-1
 
 mongodbLegacyAppDb:
   name: mongodb-enterprise-appdb-database-ubi
@@ -128,10 +104,16 @@ registry:
   initAppDb: quay.io/mongodb
   appDb: quay.io/mongodb
   agent: quay.io/mongodb
+  agentRepository: quay.io/mongodb/mongodb-agent-ubi
 
 multiCluster:
   # Specify if we want to deploy the operator in multi-cluster mode
-  clusters: []
+  clusters:
+    [
+      "MDB_CLUSTER_1_FULL_NAME",
+      "MDB_CLUSTER_2_FULL_NAME",
+      "MDB_CLUSTER_3_FULL_NAME",
+    ]
   kubeConfigSecretName: mongodb-enterprise-operator-multi-cluster-kubeconfig
   performFailOver: true
   clusterClientTimeout: 10

--- a/charts/enterprise-operator/values-openshift.yaml
+++ b/charts/enterprise-operator/values-openshift.yaml
@@ -1,21 +1,29 @@
 # Name of the Namespace to use
 namespace: mongodb
 
-# OpenShift manages security context on its own
+# Set this to true if your cluster is managing SecurityContext for you.
+# If running OpenShift (Cloud, Minishift, etc.), set this to true.
 managedSecurityContext: true
 
 operator:
   # Execution environment for the operator, dev or prod. Use dev for more verbose logging
   env: prod
 
-  # Name that will be assigned to most of the internal Kubernetes objects like ServiceAccount, Role etc.
+  # Default architecture for the operator.
+  # Values are "static" and "non-static:
+  mdbDefaultArchitecture: non-static
+
+  # Name that will be assigned to most internal Kubernetes objects like Deployment, ServiceAccount, Role etc.
   name: mongodb-enterprise-operator
 
   # Name of the operator image
   operator_image_name: mongodb-enterprise-operator-ubi
 
+  # Name of the deployment of the operator pod
+  deployment_name: mongodb-enterprise-operator
+
   # Version of mongodb-enterprise-operator
-  version: 1.24.0
+  version: 1.25.0
 
   # The Custom Resources that will be watched by the Operator. Needs to be changed if only some of the CRDs are installed
   watchedResources:
@@ -29,23 +37,51 @@ operator:
 
   affinity: {}
 
-# operator cpu requests and limits
-resources:
-  requests:
-    cpu: 500m
-    memory: 200Mi
-  limits:
-    cpu: 1100m
-    memory: 1Gi
+  # operator cpu requests and limits
+  resources:
+    requests:
+      cpu: 500m
+      memory: 200Mi
+    limits:
+      cpu: 1100m
+      memory: 1Gi
+
+  # Create operator service account and roles
+  # if false, then templates/operator-roles.yaml is excluded
+  createOperatorServiceAccount: true
+
+  vaultSecretBackend:
+  # set to true if you want the operator to store secrets in Vault
+    enabled: false
+    tlsSecretRef: ''
+
+  webhook:
+    # registerConfiguration setting (default: true) controls if the operator should automatically register ValidatingWebhookConfiguration and if required for it cluster-wide roles should be installed.
+    #
+    # Setting false:
+    #  - Adds env var MDB_WEBHOOK_REGISTER_CONFIGURATION=false to the operator deployment.
+    #  - ClusterRole and ClusterRoleBinding required to manage ValidatingWebhookConfigurations will not be installed
+    #  - The operator will not create ValidatingWebhookConfigurations upon startup.
+    #  - The operator will not create the service for the webhook. If the `operator-webhook` service was created before, it will be deleted.
+    #  - The operator will still expose the webhook's endpoint on port on MDB_WEBHOOK_PORT (if not specified, the operator uses a default 1993) in case the ValidatingWebhookConfigurations is configured externally (e.g. in OLM/OpenShift) or by the administrator manually.
+    #
+    # Setting true:
+    #  - It's the default setting, behaviour of the operator w.r.t. webhook configuration is the same as before.
+    #  - operator-webhook service will be created by the operator
+    #  - ClusterRole and ClusterRoleBinding required to manage ValidatingWebhookConfigurations will be installed.
+    #  - ValidatingWebhookConfigurations will be managed by the operator (requires cluster permissions)
+    registerConfiguration: false
+
+  replicas: 1
 
 ## Database
 database:
   name: mongodb-enterprise-database-ubi
-  version: 1.24.0
+  version: 1.25.0
 
 initDatabase:
   name: mongodb-enterprise-init-database-ubi
-  version: 1.24.0
+  version: 1.25.0
 
 ## Ops Manager
 opsManager:
@@ -53,28 +89,35 @@ opsManager:
 
 initOpsManager:
   name: mongodb-enterprise-init-ops-manager-ubi
-  version: 1.24.0
+  version: 1.25.0
 
+## Application Database
 initAppDb:
   name: mongodb-enterprise-init-appdb-ubi
-  version: 1.24.0
+  version: 1.25.0
 
 agent:
   name: mongodb-agent-ubi
-  version: 12.0.29.7785-1
+  version: 107.0.0.8502-1
+
+mongodbLegacyAppDb:
+  name: mongodb-enterprise-appdb-database-ubi
+  repo: quay.io/mongodb
 
 mongodb:
   name: mongodb-enterprise-server
   repo: quay.io/mongodb
   appdbAssumeOldFormat: false
+  imageType: ubi8
+
 
 ## Registry
 registry:
-  # The pull secret must be specified
   imagePullSecrets:
   pullPolicy: Always
-  database: quay.io/mongodb
+  # Specify if images are pulled from private registry
   operator: quay.io/mongodb
+  database: quay.io/mongodb
   initDatabase: quay.io/mongodb
   initOpsManager: quay.io/mongodb
   opsManager: quay.io/mongodb
@@ -82,10 +125,21 @@ registry:
   appDb: quay.io/mongodb
   agent: quay.io/mongodb
 
+multiCluster:
+  # Specify if we want to deploy the operator in multi-cluster mode
+  clusters: []
+  kubeConfigSecretName: mongodb-enterprise-operator-multi-cluster-kubeconfig
+  performFailOver: true
+  clusterClientTimeout: 10
+
+# Set this to false to disable subresource utilization
+# It might be required on some versions of Openshift
+subresourceEnabled: true
+
 # Versions listed here are used to populate RELATED_IMAGE_ env variables in the operator deployment.
 # Environment variables prefixed with RELATED_IMAGE_ are used by operator-sdk to generate relatedImages section
 # with sha256 digests pinning for the certified operator bundle with disconnected environment feature enabled.
-# https://docs.openshift.com/container-platform/4.11/operators/operator_sdk/osdk-generating-csvs.html#olm-enabling-operator-for-restricted-network_osdk-generating-csvs
+# https://docs.openshift.com/container-platform/4.14/operators/operator_sdk/osdk-generating-csvs.html#olm-enabling-operator-for-restricted-network_osdk-generating-csvs
 relatedImages:
   opsManager:
   - 6.0.0
@@ -110,6 +164,13 @@ relatedImages:
   - 6.0.19
   - 6.0.20
   - 6.0.21
+  - 6.0.22
+  - 6.0.23
+  - 7.0.0
+  - 7.0.1
+  - 7.0.2
+  - 7.0.3
+  - 7.0.4
   mongodb:
   - 4.4.0-ubi8
   - 4.4.1-ubi8
@@ -159,15 +220,26 @@ relatedImages:
   - 6.0.4-ubi8
   - 6.0.5-ubi8
   agent:
-  - 11.12.0.7388-1
-  - 12.0.4.7554-1
+  - 107.0.0.8465-1
+  - 107.0.0.8502-1
+  - 107.0.1.8507-1
+  - 107.0.1.8507-1_1.25.0
+  - 107.0.2.8531-1_1.25.0
+  - 107.0.3.8550-1_1.25.0
+  - 107.0.4.8567-1_1.25.0
   - 12.0.15.7646-1
   - 12.0.21.7698-1
   - 12.0.24.7719-1
   - 12.0.25.7724-1
   - 12.0.28.7763-1
   - 12.0.29.7785-1
-  - 107.0.0.8465-1
+  - 12.0.29.7785-1_1.25.0
+  - 12.0.30.7791-1
+  - 12.0.30.7791-1_1.25.0
+  - 12.0.31.7825-1_1.25.0
+  - 12.0.4.7554-1
+  - 13.10.0.8620-1
+  - 13.15.0.8788-1_1.25.0
   mongodbLegacyAppDb:
   - 4.2.11-ent
   - 4.2.2-ent
@@ -184,4 +256,3 @@ relatedImages:
   - 5.0.7-ent
   - 5.0.14-ent
   - 5.0.18-ent
-subresourceEnabled: true


### PR DESCRIPTION
## Kubernetes Enterprise Operator Release 1.25.0


This release patch has been created and it should be reviewed now.


You can add new commits to this patch if needed. After changes have
been reviewed, merge this PR for PCT to continue the release process.