### PR TITLE
Kubernetes Enterprise Operator Release 1.26.0

### DIFF
--- a/charts/enterprise-operator/Chart.yaml
+++ b/charts/enterprise-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: enterprise-operator
 description: MongoDB Kubernetes Enterprise Operator
-version: 1.25.0
+version: 1.26.0
 kubeVersion: '>=1.16-0'
 type: application
 keywords:

--- a/charts/enterprise-operator/crds/mongodb.com_mongodb.yaml
+++ b/charts/enterprise-operator/crds/mongodb.com_mongodb.yaml
@@ -3,8 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.10.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.15.0
   name: mongodb.mongodb.com
 spec:
   group: mongodb.com
@@ -40,23 +39,30 @@ spec:
       openAPIV3Schema:
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
           spec:
             properties:
               additionalMongodConfig:
-                description: 'AdditionalMongodConfig is additional configuration that
-                  can be passed to each data-bearing mongod at runtime. Uses the same
-                  structure as the mongod configuration file: https://docs.mongodb.com/manual/reference/configuration-options/'
+                description: |-
+                  AdditionalMongodConfig is additional configuration that can be passed to
+                  each data-bearing mongod at runtime. Uses the same structure as the mongod
+                  configuration file:
+                  https://docs.mongodb.com/manual/reference/configuration-options/
                 type: object
                 x-kubernetes-preserve-unknown-fields: true
               agent:
@@ -71,7 +77,8 @@ spec:
                     type: object
                 type: object
               backup:
-                description: Backup contains configuration options for configuring
+                description: |-
+                  Backup contains configuration options for configuring
                   backup for this MongoDB resource
                 properties:
                   assignmentLabels:
@@ -80,9 +87,9 @@ spec:
                       type: string
                     type: array
                   autoTerminateOnDeletion:
-                    description: AutoTerminateOnDeletion indicates if the Operator
-                      should stop and terminate the Backup before the cleanup, when
-                      the MongoDB CR is deleted
+                    description: |-
+                      AutoTerminateOnDeletion indicates if the Operator should stop and terminate the Backup before the cleanup,
+                      when the MongoDB CR is deleted
                     type: boolean
                   encryption:
                     description: Encryption settings
@@ -95,13 +102,14 @@ spec:
                             description: KMIP Client configuration
                             properties:
                               clientCertificatePrefix:
-                                description: 'A prefix used to construct KMIP client
-                                  certificate (and corresponding password) Secret
-                                  names. The names are generated using the following
-                                  pattern: KMIP Client Certificate (TLS Secret): <clientCertificatePrefix>-<CR
-                                  Name>-kmip-client KMIP Client Certificate Password:
-                                  <clientCertificatePrefix>-<CR Name>-kmip-client-password
-                                  The expected key inside is called "password".'
+                                description: |-
+                                  A prefix used to construct KMIP client certificate (and corresponding password) Secret names.
+                                  The names are generated using the following pattern:
+                                  KMIP Client Certificate (TLS Secret):
+                                    <clientCertificatePrefix>-<CR Name>-kmip-client
+                                  KMIP Client Certificate Password:
+                                    <clientCertificatePrefix>-<CR Name>-kmip-client-password
+                                    The expected key inside is called "password".
                                 type: string
                             type: object
                         required:
@@ -285,16 +293,23 @@ spec:
               connectivity:
                 properties:
                   replicaSetHorizons:
-                    description: 'ReplicaSetHorizons holds list of maps of horizons
-                      to be configured in each of MongoDB processes. Horizons map
-                      horizon names to the node addresses for each process in the
-                      replicaset, e.g.: [ { "internal": "my-rs-0.my-internal-domain.com:31843",
-                      "external": "my-rs-0.my-external-domain.com:21467" }, { "internal":
-                      "my-rs-1.my-internal-domain.com:31843", "external": "my-rs-1.my-external-domain.com:21467"
-                      }, ... ] The key of each item in the map is an arbitrary, user-chosen
-                      string that represents the name of the horizon. The value of
-                      the item is the host and, optionally, the port that this mongod
-                      node will be connected to from.'
+                    description: |-
+                      ReplicaSetHorizons holds list of maps of horizons to be configured in each of MongoDB processes.
+                      Horizons map horizon names to the node addresses for each process in the replicaset, e.g.:
+                       [
+                         {
+                           "internal": "my-rs-0.my-internal-domain.com:31843",
+                           "external": "my-rs-0.my-external-domain.com:21467"
+                         },
+                         {
+                           "internal": "my-rs-1.my-internal-domain.com:31843",
+                           "external": "my-rs-1.my-external-domain.com:21467"
+                         },
+                         ...
+                       ]
+                      The key of each item in the map is an arbitrary, user-chosen string that
+                      represents the name of the horizon. The value of the item is the host and,
+                      optionally, the port that this mongod node will be connected to from.
                     items:
                       additionalProperties:
                         type: string
@@ -518,8 +533,9 @@ spec:
                       to 9216.
                     type: integer
                   tlsSecretKeyRef:
-                    description: Name of a Secret (type kubernetes.io/tls) holding
-                      the certificates to use in the Prometheus endpoint.
+                    description: |-
+                      Name of a Secret (type kubernetes.io/tls) holding the certificates to use in the
+                      Prometheus endpoint.
                     properties:
                       key:
                         description: Key is the key in the secret storing this password.
@@ -542,8 +558,9 @@ spec:
               security:
                 properties:
                   authentication:
-                    description: Authentication holds various authentication related
-                      settings that affect this MongoDB resource.
+                    description: |-
+                      Authentication holds various authentication related settings that affect
+                      this MongoDB resource.
                     properties:
                       agents:
                         description: Agents contains authentication configuration
@@ -559,9 +576,10 @@ spec:
                                   be a valid secret key.
                                 type: string
                               name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Add other useful fields. apiVersion, kind,
-                                  uid?'
+                                description: |-
+                                  Name of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                 type: string
                               optional:
                                 description: Specify whether the Secret or its key
@@ -612,9 +630,10 @@ spec:
                                 description: The key to select.
                                 type: string
                               name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Add other useful fields. apiVersion, kind,
-                                  uid?'
+                                description: |-
+                                  Name of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                 type: string
                               optional:
                                 description: Specify whether the ConfigMap or its
@@ -726,24 +745,24 @@ spec:
                           type: string
                         type: array
                       ca:
-                        description: CA corresponds to a ConfigMap containing an entry
-                          for the CA certificate (ca.pem) used to validate the certificates
-                          created already.
+                        description: |-
+                          CA corresponds to a ConfigMap containing an entry for the CA certificate (ca.pem)
+                          used to validate the certificates created already.
                         type: string
                       enabled:
-                        description: DEPRECATED please enable TLS by setting `security.certsSecretPrefix`
-                          or `security.tls.secretRef.prefix`. Enables TLS for this
-                          resource. This will make the operator try to mount a Secret
-                          with a defined name (<resource-name>-cert). This is only
-                          used when enabling TLS on a MongoDB resource, and not on
-                          the AppDB, where TLS is configured by setting `secretRef.Name`.
+                        description: |-
+                          DEPRECATED please enable TLS by setting `security.certsSecretPrefix` or `security.tls.secretRef.prefix`.
+                          Enables TLS for this resource. This will make the operator try to mount a
+                          Secret with a defined name (<resource-name>-cert).
+                          This is only used when enabling TLS on a MongoDB resource, and not on the
+                          AppDB, where TLS is configured by setting `secretRef.Name`.
                         type: boolean
                     type: object
                 type: object
               service:
-                description: DEPRECATED please use `spec.statefulSet.spec.serviceName`
-                  to provide a custom service name. this is an optional service, it
-                  will get the name "<rsName>-service" in case not provided
+                description: |-
+                  DEPRECATED please use `spec.statefulSet.spec.serviceName` to provide a custom service name.
+                  this is an optional service, it will get the name "<rsName>-service" in case not provided
                 type: string
               shard:
                 properties:
@@ -874,10 +893,10 @@ spec:
                   type: object
                 type: array
               statefulSet:
-                description: StatefulSetConfiguration provides the statefulset override
-                  for each of the cluster's statefulset if "StatefulSetConfiguration"
-                  is specified at cluster level under "clusterSpecList" that takes
-                  precedence over the global one
+                description: |-
+                  StatefulSetConfiguration provides the statefulset override for each of the cluster's statefulset
+                  if "StatefulSetConfiguration" is specified at cluster level under "clusterSpecList" that takes precedence over
+                  the global one
                 properties:
                   metadata:
                     description: StatefulSetMetadataWrapper is a wrapper around Labels

--- a/charts/enterprise-operator/crds/mongodb.com_mongodbmulticluster.yaml
+++ b/charts/enterprise-operator/crds/mongodb.com_mongodbmulticluster.yaml
@@ -3,8 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.10.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.15.0
   name: mongodbmulticluster.mongodb.com
 spec:
   group: mongodb.com
@@ -31,23 +30,30 @@ spec:
       openAPIV3Schema:
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
           spec:
             properties:
               additionalMongodConfig:
-                description: 'AdditionalMongodConfig is additional configuration that
-                  can be passed to each data-bearing mongod at runtime. Uses the same
-                  structure as the mongod configuration file: https://docs.mongodb.com/manual/reference/configuration-options/'
+                description: |-
+                  AdditionalMongodConfig is additional configuration that can be passed to
+                  each data-bearing mongod at runtime. Uses the same structure as the mongod
+                  configuration file:
+                  https://docs.mongodb.com/manual/reference/configuration-options/
                 type: object
                 x-kubernetes-preserve-unknown-fields: true
               agent:
@@ -62,7 +68,8 @@ spec:
                     type: object
                 type: object
               backup:
-                description: Backup contains configuration options for configuring
+                description: |-
+                  Backup contains configuration options for configuring
                   backup for this MongoDB resource
                 properties:
                   assignmentLabels:
@@ -71,9 +78,9 @@ spec:
                       type: string
                     type: array
                   autoTerminateOnDeletion:
-                    description: AutoTerminateOnDeletion indicates if the Operator
-                      should stop and terminate the Backup before the cleanup, when
-                      the MongoDB CR is deleted
+                    description: |-
+                      AutoTerminateOnDeletion indicates if the Operator should stop and terminate the Backup before the cleanup,
+                      when the MongoDB CR is deleted
                     type: boolean
                   encryption:
                     description: Encryption settings
@@ -86,13 +93,14 @@ spec:
                             description: KMIP Client configuration
                             properties:
                               clientCertificatePrefix:
-                                description: 'A prefix used to construct KMIP client
-                                  certificate (and corresponding password) Secret
-                                  names. The names are generated using the following
-                                  pattern: KMIP Client Certificate (TLS Secret): <clientCertificatePrefix>-<CR
-                                  Name>-kmip-client KMIP Client Certificate Password:
-                                  <clientCertificatePrefix>-<CR Name>-kmip-client-password
-                                  The expected key inside is called "password".'
+                                description: |-
+                                  A prefix used to construct KMIP client certificate (and corresponding password) Secret names.
+                                  The names are generated using the following pattern:
+                                  KMIP Client Certificate (TLS Secret):
+                                    <clientCertificatePrefix>-<CR Name>-kmip-client
+                                  KMIP Client Certificate Password:
+                                    <clientCertificatePrefix>-<CR Name>-kmip-client-password
+                                    The expected key inside is called "password".
                                 type: string
                             type: object
                         required:
@@ -203,15 +211,15 @@ spec:
                 type: string
               clusterSpecList:
                 items:
-                  description: ClusterSpecItem is the mongodb multi-cluster spec that
-                    is specific to a particular Kubernetes cluster, this maps to the
-                    statefulset created in each cluster
+                  description: |-
+                    ClusterSpecItem is the mongodb multi-cluster spec that is specific to a
+                    particular Kubernetes cluster, this maps to the statefulset created in each cluster
                   properties:
                     clusterName:
-                      description: ClusterName is name of the cluster where the MongoDB
-                        Statefulset will be scheduled, the name should have a one
-                        on one mapping with the service-account created in the central
-                        cluster to talk to the workload clusters.
+                      description: |-
+                        ClusterName is name of the cluster where the MongoDB Statefulset will be scheduled, the
+                        name should have a one on one mapping with the service-account created in the central cluster
+                        to talk to the workload clusters.
                       type: string
                     externalAccess:
                       description: ExternalAccessConfiguration provides external access
@@ -260,9 +268,9 @@ spec:
                         "<rsName>-service" in case not provided
                       type: string
                     statefulSet:
-                      description: StatefulSetConfiguration holds the optional custom
-                        StatefulSet that should be merged into the operator created
-                        one.
+                      description: |-
+                        StatefulSetConfiguration holds the optional custom StatefulSet
+                        that should be merged into the operator created one.
                       properties:
                         metadata:
                           description: StatefulSetMetadataWrapper is a wrapper around
@@ -290,16 +298,23 @@ spec:
               connectivity:
                 properties:
                   replicaSetHorizons:
-                    description: 'ReplicaSetHorizons holds list of maps of horizons
-                      to be configured in each of MongoDB processes. Horizons map
-                      horizon names to the node addresses for each process in the
-                      replicaset, e.g.: [ { "internal": "my-rs-0.my-internal-domain.com:31843",
-                      "external": "my-rs-0.my-external-domain.com:21467" }, { "internal":
-                      "my-rs-1.my-internal-domain.com:31843", "external": "my-rs-1.my-external-domain.com:21467"
-                      }, ... ] The key of each item in the map is an arbitrary, user-chosen
-                      string that represents the name of the horizon. The value of
-                      the item is the host and, optionally, the port that this mongod
-                      node will be connected to from.'
+                    description: |-
+                      ReplicaSetHorizons holds list of maps of horizons to be configured in each of MongoDB processes.
+                      Horizons map horizon names to the node addresses for each process in the replicaset, e.g.:
+                       [
+                         {
+                           "internal": "my-rs-0.my-internal-domain.com:31843",
+                           "external": "my-rs-0.my-external-domain.com:21467"
+                         },
+                         {
+                           "internal": "my-rs-1.my-internal-domain.com:31843",
+                           "external": "my-rs-1.my-external-domain.com:21467"
+                         },
+                         ...
+                       ]
+                      The key of each item in the map is an arbitrary, user-chosen string that
+                      represents the name of the horizon. The value of the item is the host and,
+                      optionally, the port that this mongod node will be connected to from.
                     items:
                       additionalProperties:
                         type: string
@@ -310,15 +325,12 @@ spec:
                 description: Name of the Secret holding credentials information
                 type: string
               duplicateServiceObjects:
-                description: 'In few service mesh options for ex: Istio, by default
-                  we would need to duplicate the service objects created per pod in
-                  all the clusters to enable DNS resolution. Users can however configure
-                  their ServiceMesh with DNS proxy(https://istio.io/latest/docs/ops/configuration/traffic-management/dns-proxy/)
-                  enabled in which case the operator doesn''t need to create the service
-                  objects per cluster. This options tells the operator whether it
-                  should create the service objects in all the clusters or not. By
-                  default, if not specified the operator would create the duplicate
-                  svc objects.'
+                description: |-
+                  In few service mesh options for ex: Istio, by default we would need to duplicate the
+                  service objects created per pod in all the clusters to enable DNS resolution. Users can
+                  however configure their ServiceMesh with DNS proxy(https://istio.io/latest/docs/ops/configuration/traffic-management/dns-proxy/)
+                  enabled in which case the operator doesn't need to create the service objects per cluster. This options tells the operator
+                  whether it should create the service objects in all the clusters or not. By default, if not specified the operator would create the duplicate svc objects.
                 type: boolean
               externalAccess:
                 description: ExternalAccessConfiguration provides external access
@@ -390,8 +402,9 @@ spec:
                       to 9216.
                     type: integer
                   tlsSecretKeyRef:
-                    description: Name of a Secret (type kubernetes.io/tls) holding
-                      the certificates to use in the Prometheus endpoint.
+                    description: |-
+                      Name of a Secret (type kubernetes.io/tls) holding the certificates to use in the
+                      Prometheus endpoint.
                     properties:
                       key:
                         description: Key is the key in the secret storing this password.
@@ -414,8 +427,9 @@ spec:
               security:
                 properties:
                   authentication:
-                    description: Authentication holds various authentication related
-                      settings that affect this MongoDB resource.
+                    description: |-
+                      Authentication holds various authentication related settings that affect
+                      this MongoDB resource.
                     properties:
                       agents:
                         description: Agents contains authentication configuration
@@ -431,9 +445,10 @@ spec:
                                   be a valid secret key.
                                 type: string
                               name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Add other useful fields. apiVersion, kind,
-                                  uid?'
+                                description: |-
+                                  Name of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                 type: string
                               optional:
                                 description: Specify whether the Secret or its key
@@ -484,9 +499,10 @@ spec:
                                 description: The key to select.
                                 type: string
                               name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Add other useful fields. apiVersion, kind,
-                                  uid?'
+                                description: |-
+                                  Name of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                 type: string
                               optional:
                                 description: Specify whether the ConfigMap or its
@@ -598,25 +614,25 @@ spec:
                           type: string
                         type: array
                       ca:
-                        description: CA corresponds to a ConfigMap containing an entry
-                          for the CA certificate (ca.pem) used to validate the certificates
-                          created already.
+                        description: |-
+                          CA corresponds to a ConfigMap containing an entry for the CA certificate (ca.pem)
+                          used to validate the certificates created already.
                         type: string
                       enabled:
-                        description: DEPRECATED please enable TLS by setting `security.certsSecretPrefix`
-                          or `security.tls.secretRef.prefix`. Enables TLS for this
-                          resource. This will make the operator try to mount a Secret
-                          with a defined name (<resource-name>-cert). This is only
-                          used when enabling TLS on a MongoDB resource, and not on
-                          the AppDB, where TLS is configured by setting `secretRef.Name`.
+                        description: |-
+                          DEPRECATED please enable TLS by setting `security.certsSecretPrefix` or `security.tls.secretRef.prefix`.
+                          Enables TLS for this resource. This will make the operator try to mount a
+                          Secret with a defined name (<resource-name>-cert).
+                          This is only used when enabling TLS on a MongoDB resource, and not on the
+                          AppDB, where TLS is configured by setting `secretRef.Name`.
                         type: boolean
                     type: object
                 type: object
               statefulSet:
-                description: StatefulSetConfiguration provides the statefulset override
-                  for each of the cluster's statefulset if "StatefulSetConfiguration"
-                  is specified at cluster level under "clusterSpecList" that takes
-                  precedence over the global one
+                description: |-
+                  StatefulSetConfiguration provides the statefulset override for each of the cluster's statefulset
+                  if "StatefulSetConfiguration" is specified at cluster level under "clusterSpecList" that takes precedence over
+                  the global one
                 properties:
                   metadata:
                     description: StatefulSetMetadataWrapper is a wrapper around Labels
@@ -667,15 +683,15 @@ spec:
                 properties:
                   clusterStatuses:
                     items:
-                      description: ClusterStatusItem is the mongodb multi-cluster
-                        spec that is specific to a particular Kubernetes cluster,
-                        this maps to the statefulset created in each cluster
+                      description: |-
+                        ClusterStatusItem is the mongodb multi-cluster spec that is specific to a
+                        particular Kubernetes cluster, this maps to the statefulset created in each cluster
                       properties:
                         clusterName:
-                          description: ClusterName is name of the cluster where the
-                            MongoDB Statefulset will be scheduled, the name should
-                            have a one on one mapping with the service-account created
-                            in the central cluster to talk to the workload clusters.
+                          description: |-
+                            ClusterName is name of the cluster where the MongoDB Statefulset will be scheduled, the
+                            name should have a one on one mapping with the service-account created in the central cluster
+                            to talk to the workload clusters.
                           type: string
                         lastTransition:
                           type: string

--- a/charts/enterprise-operator/crds/mongodb.com_mongodbusers.yaml
+++ b/charts/enterprise-operator/crds/mongodb.com_mongodbusers.yaml
@@ -3,8 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.10.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.15.0
   name: mongodbusers.mongodb.com
 spec:
   group: mongodb.com
@@ -31,14 +30,19 @@ spec:
       openAPIV3Schema:
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -58,8 +62,10 @@ spec:
                 - name
                 type: object
               passwordSecretKeyRef:
-                description: 'SecretKeyRef is a reference to a value in a given secret
-                  in the same namespace. Based on: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#secretkeyselector-v1-core'
+                description: |-
+                  SecretKeyRef is a reference to a value in a given secret in the same
+                  namespace. Based on:
+                  https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#secretkeyselector-v1-core
                 properties:
                   key:
                     type: string

--- a/charts/enterprise-operator/crds/mongodb.com_opsmanagers.yaml
+++ b/charts/enterprise-operator/crds/mongodb.com_opsmanagers.yaml
@@ -3,8 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.10.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.15.0
   name: opsmanagers.mongodb.com
 spec:
   group: mongodb.com
@@ -53,29 +52,37 @@ spec:
           within your Kubernetes cluster
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
           spec:
             properties:
               adminCredentials:
-                description: 'AdminSecret is the secret for the first admin user to
-                  create has the fields: "Username", "Password", "FirstName", "LastName"'
+                description: |-
+                  AdminSecret is the secret for the first admin user to create
+                  has the fields: "Username", "Password", "FirstName", "LastName"
                 type: string
               applicationDatabase:
                 properties:
                   additionalMongodConfig:
-                    description: 'AdditionalMongodConfig are additional configurations
-                      that can be passed to each data-bearing mongod at runtime. Uses
-                      the same structure as the mongod configuration file: https://docs.mongodb.com/manual/reference/configuration-options/'
+                    description: |-
+                      AdditionalMongodConfig are additional configurations that can be passed to
+                      each data-bearing mongod at runtime. Uses the same structure as the mongod
+                      configuration file:
+                      https://docs.mongodb.com/manual/reference/configuration-options/
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
                   agent:
@@ -89,8 +96,9 @@ spec:
                           all processes.
                         properties:
                           includeAuditLogsWithMongoDBLogs:
-                            description: set to 'true' to have the Automation Agent
-                              rotate the audit files along with mongodb log files
+                            description: |-
+                              set to 'true' to have the Automation Agent rotate the audit files along
+                              with mongodb log files
                             type: boolean
                           numTotal:
                             description: maximum number of log files to have total
@@ -99,14 +107,15 @@ spec:
                             description: maximum number of log files to leave uncompressed
                             type: integer
                           percentOfDiskspace:
-                            description: Maximum percentage of the total disk space
-                              these log files should take up. The string needs to
-                              be able to be converted to float64
+                            description: |-
+                              Maximum percentage of the total disk space these log files should take up.
+                              The string needs to be able to be converted to float64
                             type: string
                           sizeThresholdMB:
-                            description: Maximum size for an individual log file before
-                              rotation. The string needs to be able to be converted
-                              to float64. Fractional values of MB are supported.
+                            description: |-
+                              Maximum size for an individual log file before rotation.
+                              The string needs to be able to be converted to float64.
+                              Fractional values of MB are supported.
                             type: string
                           timeThresholdHrs:
                             description: maximum hours for an individual log file
@@ -138,10 +147,9 @@ spec:
                         type: object
                     type: object
                   automationConfig:
-                    description: AutomationConfigOverride holds any fields that will
-                      be merged on top of the Automation Config that the operator
-                      creates for the AppDB. Currently only the process.disabled and
-                      logRotate field is recognized.
+                    description: |-
+                      AutomationConfigOverride holds any fields that will be merged on top of the Automation Config
+                      that the operator creates for the AppDB. Currently only the process.disabled and logRotate field is recognized.
                     properties:
                       processes:
                         items:
@@ -156,9 +164,9 @@ spec:
                                 them as float64
                               properties:
                                 includeAuditLogsWithMongoDBLogs:
-                                  description: set to 'true' to have the Automation
-                                    Agent rotate the audit files along with mongodb
-                                    log files
+                                  description: |-
+                                    set to 'true' to have the Automation Agent rotate the audit files along
+                                    with mongodb log files
                                   type: boolean
                                 numTotal:
                                   description: maximum number of log files to have
@@ -169,15 +177,15 @@ spec:
                                     uncompressed
                                   type: integer
                                 percentOfDiskspace:
-                                  description: Maximum percentage of the total disk
-                                    space these log files should take up. The string
-                                    needs to be able to be converted to float64
+                                  description: |-
+                                    Maximum percentage of the total disk space these log files should take up.
+                                    The string needs to be able to be converted to float64
                                   type: string
                                 sizeThresholdMB:
-                                  description: Maximum size for an individual log
-                                    file before rotation. The string needs to be able
-                                    to be converted to float64. Fractional values
-                                    of MB are supported.
+                                  description: |-
+                                    Maximum size for an individual log file before rotation.
+                                    The string needs to be able to be converted to float64.
+                                    Fractional values of MB are supported.
                                   type: string
                                 timeThresholdHrs:
                                   description: maximum hours for an individual log
@@ -197,10 +205,11 @@ spec:
                       replicaSet:
                         properties:
                           settings:
-                            description: MapWrapper is a wrapper for a map to be used
-                              by other structs. The CRD generator does not support
-                              map[string]interface{} on the top level and hence we
-                              need to work around this with a wrapping struct.
+                            description: |-
+                              MapWrapper is a wrapper for a map to be used by other structs.
+                              The CRD generator does not support map[string]interface{}
+                              on the top level and hence we need to work around this with
+                              a wrapping struct.
                             type: object
                             x-kubernetes-preserve-unknown-fields: true
                         type: object
@@ -217,15 +226,15 @@ spec:
                     type: string
                   clusterSpecList:
                     items:
-                      description: ClusterSpecItem is the mongodb multi-cluster spec
-                        that is specific to a particular Kubernetes cluster, this
-                        maps to the statefulset created in each cluster
+                      description: |-
+                        ClusterSpecItem is the mongodb multi-cluster spec that is specific to a
+                        particular Kubernetes cluster, this maps to the statefulset created in each cluster
                       properties:
                         clusterName:
-                          description: ClusterName is name of the cluster where the
-                            MongoDB Statefulset will be scheduled, the name should
-                            have a one on one mapping with the service-account created
-                            in the central cluster to talk to the workload clusters.
+                          description: |-
+                            ClusterName is name of the cluster where the MongoDB Statefulset will be scheduled, the
+                            name should have a one on one mapping with the service-account created in the central cluster
+                            to talk to the workload clusters.
                           type: string
                         externalAccess:
                           description: ExternalAccessConfiguration provides external
@@ -275,9 +284,9 @@ spec:
                             name "<rsName>-service" in case not provided
                           type: string
                         statefulSet:
-                          description: StatefulSetConfiguration holds the optional
-                            custom StatefulSet that should be merged into the operator
-                            created one.
+                          description: |-
+                            StatefulSetConfiguration holds the optional custom StatefulSet
+                            that should be merged into the operator created one.
                           properties:
                             metadata:
                               description: StatefulSetMetadataWrapper is a wrapper
@@ -305,17 +314,23 @@ spec:
                   connectivity:
                     properties:
                       replicaSetHorizons:
-                        description: 'ReplicaSetHorizons holds list of maps of horizons
-                          to be configured in each of MongoDB processes. Horizons
-                          map horizon names to the node addresses for each process
-                          in the replicaset, e.g.: [ { "internal": "my-rs-0.my-internal-domain.com:31843",
-                          "external": "my-rs-0.my-external-domain.com:21467" }, {
-                          "internal": "my-rs-1.my-internal-domain.com:31843", "external":
-                          "my-rs-1.my-external-domain.com:21467" }, ... ] The key
-                          of each item in the map is an arbitrary, user-chosen string
-                          that represents the name of the horizon. The value of the
-                          item is the host and, optionally, the port that this mongod
-                          node will be connected to from.'
+                        description: |-
+                          ReplicaSetHorizons holds list of maps of horizons to be configured in each of MongoDB processes.
+                          Horizons map horizon names to the node addresses for each process in the replicaset, e.g.:
+                           [
+                             {
+                               "internal": "my-rs-0.my-internal-domain.com:31843",
+                               "external": "my-rs-0.my-external-domain.com:21467"
+                             },
+                             {
+                               "internal": "my-rs-1.my-internal-domain.com:31843",
+                               "external": "my-rs-1.my-external-domain.com:21467"
+                             },
+                             ...
+                           ]
+                          The key of each item in the map is an arbitrary, user-chosen string that
+                          represents the name of the horizon. The value of the item is the host and,
+                          optionally, the port that this mongod node will be connected to from.
                         items:
                           additionalProperties:
                             type: string
@@ -355,9 +370,10 @@ spec:
                     minimum: 3
                     type: integer
                   monitoringAgent:
-                    description: Specify configuration like startup flags just for
-                      the MonitoringAgent. These take precedence over the flags set
-                      in AutomationAgent
+                    description: |-
+                      Specify configuration like startup flags just for the MonitoringAgent.
+                      These take precedence over
+                      the flags set in AutomationAgent
                     properties:
                       logLevel:
                         type: string
@@ -377,9 +393,9 @@ spec:
                         type: object
                     type: object
                   passwordSecretKeyRef:
-                    description: PasswordSecretKeyRef contains a reference to the
-                      secret which contains the password for the mongodb-ops-manager
-                      SCRAM-SHA user
+                    description: |-
+                      PasswordSecretKeyRef contains a reference to the secret which contains the password
+                      for the mongodb-ops-manager SCRAM-SHA user
                     properties:
                       key:
                         type: string
@@ -467,8 +483,9 @@ spec:
                           to 9216.
                         type: integer
                       tlsSecretKeyRef:
-                        description: Name of a Secret (type kubernetes.io/tls) holding
-                          the certificates to use in the Prometheus endpoint.
+                        description: |-
+                          Name of a Secret (type kubernetes.io/tls) holding the certificates to use in the
+                          Prometheus endpoint.
                         properties:
                           key:
                             description: Key is the key in the secret storing this
@@ -491,8 +508,9 @@ spec:
                   security:
                     properties:
                       authentication:
-                        description: Authentication holds various authentication related
-                          settings that affect this MongoDB resource.
+                        description: |-
+                          Authentication holds various authentication related settings that affect
+                          this MongoDB resource.
                         properties:
                           agents:
                             description: Agents contains authentication configuration
@@ -509,10 +527,10 @@ spec:
                                       be a valid secret key.
                                     type: string
                                   name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
+                                    description: |-
+                                      Name of the referent.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                     type: string
                                   optional:
                                     description: Specify whether the Secret or its
@@ -564,10 +582,10 @@ spec:
                                     description: The key to select.
                                     type: string
                                   name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
+                                    description: |-
+                                      Name of the referent.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                     type: string
                                   optional:
                                     description: Specify whether the ConfigMap or
@@ -679,18 +697,17 @@ spec:
                               type: string
                             type: array
                           ca:
-                            description: CA corresponds to a ConfigMap containing
-                              an entry for the CA certificate (ca.pem) used to validate
-                              the certificates created already.
+                            description: |-
+                              CA corresponds to a ConfigMap containing an entry for the CA certificate (ca.pem)
+                              used to validate the certificates created already.
                             type: string
                           enabled:
-                            description: DEPRECATED please enable TLS by setting `security.certsSecretPrefix`
-                              or `security.tls.secretRef.prefix`. Enables TLS for
-                              this resource. This will make the operator try to mount
-                              a Secret with a defined name (<resource-name>-cert).
-                              This is only used when enabling TLS on a MongoDB resource,
-                              and not on the AppDB, where TLS is configured by setting
-                              `secretRef.Name`.
+                            description: |-
+                              DEPRECATED please enable TLS by setting `security.certsSecretPrefix` or `security.tls.secretRef.prefix`.
+                              Enables TLS for this resource. This will make the operator try to mount a
+                              Secret with a defined name (<resource-name>-cert).
+                              This is only used when enabling TLS on a MongoDB resource, and not on the
+                              AppDB, where TLS is configured by setting `secretRef.Name`.
                             type: boolean
                         type: object
                     type: object
@@ -725,10 +742,9 @@ spec:
                     type: array
                   blockStores:
                     items:
-                      description: DataStoreConfig is the description of the config
-                        used to reference to database. Reused by Oplog and Block stores
-                        Optionally references the user if the Mongodb is configured
-                        with authentication
+                      description: |-
+                        DataStoreConfig is the description of the config used to reference to database. Reused by Oplog and Block stores
+                        Optionally references the user if the Mongodb is configured with authentication
                       properties:
                         assignmentLabels:
                           description: Assignment Labels set in the Ops Manager
@@ -773,14 +789,17 @@ spec:
                             description: KMIP Server configuration
                             properties:
                               ca:
-                                description: CA corresponds to a ConfigMap containing
-                                  an entry for the CA certificate (ca.pem) used for
-                                  KMIP authentication
+                                description: |-
+                                  CA corresponds to a ConfigMap containing an entry for the CA certificate (ca.pem)
+                                  used for KMIP authentication
                                 type: string
                               url:
-                                description: 'KMIP Server url in the following format:
-                                  hostname:port Valid examples are: 10.10.10.3:5696
-                                  my-kmip-server.mycorp.com:5696 kmip-svc.svc.cluster.local:5696'
+                                description: |-
+                                  KMIP Server url in the following format: hostname:port
+                                  Valid examples are:
+                                    10.10.10.3:5696
+                                    my-kmip-server.mycorp.com:5696
+                                    kmip-svc.svc.cluster.local:5696
                                 pattern: '[^\:]+:[0-9]{0,5}'
                                 type: string
                             required:
@@ -826,10 +845,9 @@ spec:
                     description: OplogStoreConfigs describes the list of oplog store
                       configs used for backup
                     items:
-                      description: DataStoreConfig is the description of the config
-                        used to reference to database. Reused by Oplog and Block stores
-                        Optionally references the user if the Mongodb is configured
-                        with authentication
+                      description: |-
+                        DataStoreConfig is the description of the config used to reference to database. Reused by Oplog and Block stores
+                        Optionally references the user if the Mongodb is configured with authentication
                       properties:
                         assignmentLabels:
                           description: Assignment Labels set in the Ops Manager
@@ -860,9 +878,9 @@ spec:
                       type: object
                     type: array
                   queryableBackupSecretRef:
-                    description: QueryableBackupSecretRef references the secret which
-                      contains the pem file which is used for queryable backup. This
-                      will be mounted into the Ops Manager pod.
+                    description: |-
+                      QueryableBackupSecretRef references the secret which contains the pem file which is used
+                      for queryable backup. This will be mounted into the Ops Manager pod.
                     properties:
                       name:
                         type: string
@@ -880,16 +898,16 @@ spec:
                             type: string
                           type: array
                         customCertificate:
-                          description: 'Set this to "true" to use the appDBCa as a
-                            CA to access S3. Deprecated: This has been replaced by
-                            CustomCertificateSecretRefs, In the future all custom
-                            certificates, which includes the appDBCa for s3Config
-                            should be configured in CustomCertificateSecretRefs instead.'
+                          description: |-
+                            Set this to "true" to use the appDBCa as a CA to access S3.
+                            Deprecated: This has been replaced by CustomCertificateSecretRefs,
+                            In the future all custom certificates, which includes the appDBCa
+                            for s3Config should be configured in CustomCertificateSecretRefs instead.
                           type: boolean
                         customCertificateSecretRefs:
-                          description: CustomCertificateSecretRefs is a list of valid
-                            Certificate Authority certificate secrets that apply to
-                            the associated S3 bucket.
+                          description: |-
+                            CustomCertificateSecretRefs is a list of valid Certificate Authority certificate secrets
+                            that apply to the associated S3 bucket.
                           items:
                             description: SecretKeySelector selects a key of a Secret.
                             properties:
@@ -898,9 +916,10 @@ spec:
                                   be a valid secret key.
                                 type: string
                               name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Add other useful fields. apiVersion, kind,
-                                  uid?'
+                                description: |-
+                                  Name of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                 type: string
                               optional:
                                 description: Specify whether the Secret or its key
@@ -912,9 +931,9 @@ spec:
                             x-kubernetes-map-type: atomic
                           type: array
                         irsaEnabled:
-                          description: 'This is only set to "true" when a user is
-                            running in EKS and is using AWS IRSA to configure S3 snapshot
-                            store. For more details refer this: https://aws.amazon.com/blogs/opensource/introducing-fine-grained-iam-roles-service-accounts/'
+                          description: |-
+                            This is only set to "true" when a user is running in EKS and is using AWS IRSA to configure
+                            S3 snapshot store. For more details refer this: https://aws.amazon.com/blogs/opensource/introducing-fine-grained-iam-roles-service-accounts/
                           type: boolean
                         mongodbResourceRef:
                           properties:
@@ -966,16 +985,16 @@ spec:
                             type: string
                           type: array
                         customCertificate:
-                          description: 'Set this to "true" to use the appDBCa as a
-                            CA to access S3. Deprecated: This has been replaced by
-                            CustomCertificateSecretRefs, In the future all custom
-                            certificates, which includes the appDBCa for s3Config
-                            should be configured in CustomCertificateSecretRefs instead.'
+                          description: |-
+                            Set this to "true" to use the appDBCa as a CA to access S3.
+                            Deprecated: This has been replaced by CustomCertificateSecretRefs,
+                            In the future all custom certificates, which includes the appDBCa
+                            for s3Config should be configured in CustomCertificateSecretRefs instead.
                           type: boolean
                         customCertificateSecretRefs:
-                          description: CustomCertificateSecretRefs is a list of valid
-                            Certificate Authority certificate secrets that apply to
-                            the associated S3 bucket.
+                          description: |-
+                            CustomCertificateSecretRefs is a list of valid Certificate Authority certificate secrets
+                            that apply to the associated S3 bucket.
                           items:
                             description: SecretKeySelector selects a key of a Secret.
                             properties:
@@ -984,9 +1003,10 @@ spec:
                                   be a valid secret key.
                                 type: string
                               name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Add other useful fields. apiVersion, kind,
-                                  uid?'
+                                description: |-
+                                  Name of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                 type: string
                               optional:
                                 description: Specify whether the Secret or its key
@@ -998,9 +1018,9 @@ spec:
                             x-kubernetes-map-type: atomic
                           type: array
                         irsaEnabled:
-                          description: 'This is only set to "true" when a user is
-                            running in EKS and is using AWS IRSA to configure S3 snapshot
-                            store. For more details refer this: https://aws.amazon.com/blogs/opensource/introducing-fine-grained-iam-roles-service-accounts/'
+                          description: |-
+                            This is only set to "true" when a user is running in EKS and is using AWS IRSA to configure
+                            S3 snapshot store. For more details refer this: https://aws.amazon.com/blogs/opensource/introducing-fine-grained-iam-roles-service-accounts/
                           type: boolean
                         mongodbResourceRef:
                           properties:
@@ -1044,9 +1064,9 @@ spec:
                       type: object
                     type: array
                   statefulSet:
-                    description: StatefulSetConfiguration holds the optional custom
-                      StatefulSet that should be merged into the operator created
-                      one.
+                    description: |-
+                      StatefulSetConfiguration holds the optional custom StatefulSet
+                      that should be merged into the operator created one.
                     properties:
                       metadata:
                         description: StatefulSetMetadataWrapper is a wrapper around
@@ -1074,8 +1094,9 @@ spec:
                 format: hostname
                 type: string
               clusterName:
-                description: 'Deprecated: This has been replaced by the ClusterDomain
-                  which should be used instead'
+                description: |-
+                  Deprecated: This has been replaced by the ClusterDomain which should be
+                  used instead
                 format: hostname
                 type: string
               clusterSpecList:
@@ -1084,9 +1105,9 @@ spec:
                     Ops Manager multi-cluster deployment.
                   properties:
                     backup:
-                      description: Backup contains settings to override from top-level
-                        `spec.backup` for this member cluster. If the value is not
-                        set here, then the value is taken from `spec.backup`.
+                      description: |-
+                        Backup contains settings to override from top-level `spec.backup` for this member cluster.
+                        If the value is not set here, then the value is taken from `spec.backup`.
                       properties:
                         assignmentLabels:
                           description: Assignment Labels set in the Ops Manager
@@ -1145,30 +1166,25 @@ spec:
                       format: hostname
                       type: string
                     clusterName:
-                      description: ClusterName is name of the cluster where the Ops
-                        Manager Statefulset will be scheduled. The operator is using
-                        ClusterName to find API credentials in `mongodb-enterprise-operator-member-list`
-                        config map to use for this member cluster. If the credentials
-                        are not found, then the member cluster is considered unreachable
-                        and ignored in the reconcile process.
+                      description: |-
+                        ClusterName is name of the cluster where the Ops Manager Statefulset will be scheduled.
+                        The operator is using ClusterName to find API credentials in `mongodb-enterprise-operator-member-list` config map to use for this member cluster.
+                        If the credentials are not found, then the member cluster is considered unreachable and ignored in the reconcile process.
                       type: string
                     configuration:
                       additionalProperties:
                         type: string
-                      description: The configuration properties passed to Ops Manager
-                        and Backup Daemon in this cluster. If specified (not empty)
-                        then this field overrides `spec.configuration` field entirely.
-                        If not specified, then `spec.configuration` field is used
-                        for the Ops Manager and Backup Daemon instances in this cluster.
+                      description: |-
+                        The configuration properties passed to Ops Manager and Backup Daemon in this cluster.
+                        If specified (not empty) then this field overrides `spec.configuration` field entirely.
+                        If not specified, then `spec.configuration` field is used for the Ops Manager and Backup Daemon instances in this cluster.
                       type: object
                     externalConnectivity:
-                      description: MongoDBOpsManagerExternalConnectivity if sets allows
-                        for the creation of a Service for accessing Ops Manager instances
-                        in this member cluster from outside the Kubernetes cluster.
-                        If specified (even if provided empty) then this field overrides
-                        `spec.externalConnectivity` field entirely. If not specified,
-                        then `spec.externalConnectivity` field is used for the Ops
-                        Manager and Backup Daemon instances in this cluster.
+                      description: |-
+                        MongoDBOpsManagerExternalConnectivity if sets allows for the creation of a Service for
+                        accessing Ops Manager instances in this member cluster from outside the Kubernetes cluster.
+                        If specified (even if provided empty) then this field overrides `spec.externalConnectivity` field entirely.
+                        If not specified, then `spec.externalConnectivity` field is used for the Ops Manager and Backup Daemon instances in this cluster.
                       properties:
                         annotations:
                           additionalProperties:
@@ -1181,9 +1197,9 @@ spec:
                             Service when creating a ClusterIP type Service
                           type: string
                         externalTrafficPolicy:
-                          description: ExternalTrafficPolicy mechanism to preserve
-                            the client source IP. Only supported on GCE and Google
-                            Kubernetes Engine.
+                          description: |-
+                            ExternalTrafficPolicy mechanism to preserve the client source IP.
+                            Only supported on GCE and Google Kubernetes Engine.
                           enum:
                           - Cluster
                           - Local
@@ -1208,12 +1224,10 @@ spec:
                       - type
                       type: object
                     jvmParameters:
-                      description: JVM parameters to pass to Ops Manager and Backup
-                        Daemon instances in this member cluster. If specified (not
-                        empty) then this field overrides `spec.jvmParameters` field
-                        entirely. If not specified, then `spec.jvmParameters` field
-                        is used for the Ops Manager and Backup Daemon instances in
-                        this cluster.
+                      description: |-
+                        JVM parameters to pass to Ops Manager and Backup Daemon instances in this member cluster.
+                        If specified (not empty) then this field overrides `spec.jvmParameters` field entirely.
+                        If not specified, then `spec.jvmParameters` field is used for the Ops Manager and Backup Daemon instances in this cluster.
                       items:
                         type: string
                       type: array
@@ -1222,12 +1236,10 @@ spec:
                         cluster.
                       type: integer
                     statefulSet:
-                      description: Configure custom StatefulSet configuration to override
-                        in Ops Manager's statefulset in this member cluster. If specified
-                        (even if provided empty) then this field overrides `spec.externalConnectivity`
-                        field entirely. If not specified, then `spec.externalConnectivity`
-                        field is used for the Ops Manager and Backup Daemon instances
-                        in this cluster.
+                      description: |-
+                        Configure custom StatefulSet configuration to override in Ops Manager's statefulset in this member cluster.
+                        If specified (even if provided empty) then this field overrides `spec.externalConnectivity` field entirely.
+                        If not specified, then `spec.externalConnectivity` field is used for the Ops Manager and Backup Daemon instances in this cluster.
                       properties:
                         metadata:
                           description: StatefulSetMetadataWrapper is a wrapper around
@@ -1259,9 +1271,9 @@ spec:
                   Daemon
                 type: object
               externalConnectivity:
-                description: MongoDBOpsManagerExternalConnectivity if sets allows
-                  for the creation of a Service for accessing this Ops Manager resource
-                  from outside the Kubernetes cluster.
+                description: |-
+                  MongoDBOpsManagerExternalConnectivity if sets allows for the creation of a Service for
+                  accessing this Ops Manager resource from outside the Kubernetes cluster.
                 properties:
                   annotations:
                     additionalProperties:
@@ -1274,8 +1286,9 @@ spec:
                       when creating a ClusterIP type Service
                     type: string
                   externalTrafficPolicy:
-                    description: ExternalTrafficPolicy mechanism to preserve the client
-                      source IP. Only supported on GCE and Google Kubernetes Engine.
+                    description: |-
+                      ExternalTrafficPolicy mechanism to preserve the client source IP.
+                      Only supported on GCE and Google Kubernetes Engine.
                     enum:
                     - Cluster
                     - Local
@@ -1299,9 +1312,9 @@ spec:
                 - type
                 type: object
               internalConnectivity:
-                description: InternalConnectivity if set allows for overriding the
-                  settings of the default service used for internal connectivity to
-                  the OpsManager servers.
+                description: |-
+                  InternalConnectivity if set allows for overriding the settings of the default service
+                  used for internal connectivity to the OpsManager servers.
                 properties:
                   annotations:
                     additionalProperties:
@@ -1314,8 +1327,9 @@ spec:
                       when creating a ClusterIP type Service
                     type: string
                   externalTrafficPolicy:
-                    description: ExternalTrafficPolicy mechanism to preserve the client
-                      source IP. Only supported on GCE and Google Kubernetes Engine.
+                    description: |-
+                      ExternalTrafficPolicy mechanism to preserve the client source IP.
+                      Only supported on GCE and Google Kubernetes Engine.
                     enum:
                     - Cluster
                     - Local
@@ -1344,15 +1358,11 @@ spec:
                   type: string
                 type: array
               opsManagerURL:
-                description: OpsManagerURL specified the URL with which the operator
-                  and AppDB monitoring agent should access Ops Manager instance (or
-                  instances). When not set, the operator is using FQDN of Ops Manager's
-                  headless service `{name}-svc.{namespace}.svc.cluster.local` to connect
-                  to the instance. If that URL cannot be used, then URL in this field
-                  should be provided for the operator to connect to Ops Manager instances.
+                description: |-
+                  OpsManagerURL specified the URL with which the operator and AppDB monitoring agent should access Ops Manager instance (or instances).
+                  When not set, the operator is using FQDN of Ops Manager's headless service `{name}-svc.{namespace}.svc.cluster.local` to connect to the instance. If that URL cannot be used, then URL in this field should be provided for the operator to connect to Ops Manager instances.
                   It defaults (and if not set) to SingleCluster. If MultiCluster specified,
-                  then clusterSpecList field is mandatory and at least one member
-                  cluster has to be specified.
+                  then clusterSpecList field is mandatory and at least one member cluster has to be specified.
                 type: string
               replicas:
                 minimum: 1
@@ -1398,10 +1408,10 @@ spec:
                 - spec
                 type: object
               topology:
-                description: Topology sets the desired cluster topology of Ops Manager
-                  deployment. It defaults (and if not set) to SingleCluster. If MultiCluster
-                  specified, then clusterSpecList field is mandatory and at least
-                  one member cluster has to be specified.
+                description: |-
+                  Topology sets the desired cluster topology of Ops Manager deployment.
+                  It defaults (and if not set) to SingleCluster. If MultiCluster specified,
+                  then clusterSpecList field is mandatory and at least one member cluster has to be specified.
                 enum:
                 - SingleCluster
                 - MultiCluster

--- a/charts/enterprise-operator/templates/operator-roles.yaml
+++ b/charts/enterprise-operator/templates/operator-roles.yaml
@@ -122,7 +122,7 @@ subjects:
 ---
 
 {{/* This cluster role and binding is necessary to allow the operator to automatically register ValidatingWebhookConfiguration. */}}
-{{- if .Values.operator.webhook.registerConfiguration }}
+{{- if and .Values.operator.webhook.registerConfiguration .Values.operator.webhook.installClusterRole }}
 {{- if not (lookup "rbac.authorization.k8s.io/v1" "ClusterRole" "" "mongodb-enterprise-operator-mongodb-webhook") }}
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -151,6 +151,7 @@ rules:
       - delete
 {{- end }} {{/* if not (lookup ... */}}
 ---
+
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -164,4 +165,4 @@ subjects:
     name: {{ .Values.operator.name }}
     namespace: {{ include "mongodb-enterprise-operator.namespace" . }}
 
-{{- end }} {{/* if .Values.operator.webhook.registerConfiguration */}}
+{{- end }} {{/* if and .Values.operator.webhook.registerConfiguration .Values.operator.webhook.installClusterRole */}}

--- a/charts/enterprise-operator/templates/operator.yaml
+++ b/charts/enterprise-operator/templates/operator.yaml
@@ -43,7 +43,7 @@ spec:
 {{- end }}
       containers:
         - name: {{ .Values.operator.name }}
-          image: "{{ .Values.registry.operator }}/{{ .Values.operator.operator_image_name }}:{{ .Values.operator.version }}{{ .Values.build }}"
+          image: "{{ .Values.registry.operator }}/{{ .Values.operator.operator_image_name }}:{{ .Values.operator.version }}{{ .Values.operator.build }}"
           imagePullPolicy: {{ .Values.registry.pullPolicy }}
           {{- if .Values.operator.watchedResources }}
           args:
@@ -165,6 +165,10 @@ spec:
     {{- if not .Values.operator.webhook.registerConfiguration }}
             - name: MDB_WEBHOOK_REGISTER_CONFIGURATION
               value: "false"
+    {{- end }}
+    {{- if .Values.operator.maxConcurrentReconciles }}
+            - name: MDB_MAX_CONCURRENT_RECONCILES
+              value: "{{ .Values.operator.maxConcurrentReconciles }}"
     {{- end }}
     {{- if .Values.relatedImages }}
             - name: RELATED_IMAGE_{{ $mongodbEnterpriseDatabaseImageEnv }}_{{ $databaseVersion | replace "." "_" | replace "-" "_" }}

--- a/charts/enterprise-operator/values-multi-cluster.yaml
+++ b/charts/enterprise-operator/values-multi-cluster.yaml
@@ -45,7 +45,8 @@ operator:
       cpu: 1100m
       memory: 1Gi
 
-  # Create operator-service account
+  # Create operator service account and roles
+  # if false, then templates/operator-roles.yaml is excluded
   createOperatorServiceAccount: true
 
   vaultSecretBackend:

--- a/charts/enterprise-operator/values-openshift.yaml
+++ b/charts/enterprise-operator/values-openshift.yaml
@@ -23,7 +23,7 @@ operator:
   deployment_name: mongodb-enterprise-operator
 
   # Version of mongodb-enterprise-operator
-  version: 1.25.0
+  version: 1.26.0
 
   # The Custom Resources that will be watched by the Operator. Needs to be changed if only some of the CRDs are installed
   watchedResources:
@@ -77,11 +77,11 @@ operator:
 ## Database
 database:
   name: mongodb-enterprise-database-ubi
-  version: 1.25.0
+  version: 1.26.0
 
 initDatabase:
   name: mongodb-enterprise-init-database-ubi
-  version: 1.25.0
+  version: 1.26.0
 
 ## Ops Manager
 opsManager:
@@ -89,12 +89,12 @@ opsManager:
 
 initOpsManager:
   name: mongodb-enterprise-init-ops-manager-ubi
-  version: 1.25.0
+  version: 1.26.0
 
 ## Application Database
 initAppDb:
   name: mongodb-enterprise-init-appdb-ubi
-  version: 1.25.0
+  version: 1.26.0
 
 agent:
   name: mongodb-agent-ubi
@@ -171,6 +171,8 @@ relatedImages:
   - 7.0.2
   - 7.0.3
   - 7.0.4
+  - 7.0.6
+  - 7.0.7
   mongodb:
   - 4.4.0-ubi8
   - 4.4.1-ubi8
@@ -224,22 +226,38 @@ relatedImages:
   - 107.0.0.8502-1
   - 107.0.1.8507-1
   - 107.0.1.8507-1_1.25.0
+  - 107.0.1.8507-1_1.26.0
+  - 107.0.2.8531-1
   - 107.0.2.8531-1_1.25.0
+  - 107.0.2.8531-1_1.26.0
+  - 107.0.3.8550-1
   - 107.0.3.8550-1_1.25.0
+  - 107.0.3.8550-1_1.26.0
+  - 107.0.4.8567-1
   - 107.0.4.8567-1_1.25.0
-  - 12.0.15.7646-1
-  - 12.0.21.7698-1
+  - 107.0.4.8567-1_1.26.0
+  - 107.0.6.8587-1
+  - 107.0.6.8587-1_1.25.0
+  - 107.0.6.8587-1_1.26.0
+  - 107.0.7.8596-1
+  - 107.0.7.8596-1_1.25.0
+  - 107.0.7.8596-1_1.26.0
   - 12.0.24.7719-1
   - 12.0.25.7724-1
   - 12.0.28.7763-1
   - 12.0.29.7785-1
   - 12.0.29.7785-1_1.25.0
+  - 12.0.29.7785-1_1.26.0
   - 12.0.30.7791-1
   - 12.0.30.7791-1_1.25.0
+  - 12.0.30.7791-1_1.26.0
+  - 12.0.31.7825-1
   - 12.0.31.7825-1_1.25.0
-  - 12.0.4.7554-1
+  - 12.0.31.7825-1_1.26.0
   - 13.10.0.8620-1
-  - 13.15.0.8788-1_1.25.0
+  - 13.17.0.8870-1
+  - 13.17.0.8870-1_1.25.0
+  - 13.17.0.8870-1_1.26.0
   mongodbLegacyAppDb:
   - 4.2.11-ent
   - 4.2.2-ent

--- a/charts/enterprise-operator/values.yaml
+++ b/charts/enterprise-operator/values.yaml
@@ -20,7 +20,7 @@ operator:
   deployment_name: mongodb-enterprise-operator
 
   # Version of mongodb-enterprise-operator
-  version: 1.25.0
+  version: 1.26.0
 
   # The Custom Resources that will be watched by the Operator. Needs to be changed if only some of the CRDs are installed
   watchedResources:
@@ -43,6 +43,16 @@ operator:
       cpu: 1100m
       memory: 1Gi
 
+  # Control how many reconciles can be performed in parallel.
+  # It sets MaxConcurrentReconciles https://pkg.go.dev/github.com/kubernetes-sigs/controller-runtime/pkg/controller#Options).
+  # Increasing the number of concurrent reconciles will decrease the time needed to reconcile all watched resources.
+  # But it might result in increased load on Ops Manager API, K8S API server and will require allocating more cpu and memory for the operator deployment.
+  #
+  # This setting works independently for all watched CRD types, so setting doesn't mean the operator will use only 4 workers in total, but
+  # each CRD type (MongoDB, MongoDBMultiCluster, MongoDBOpsManager, MongoDBUser) will be reconciled with 4 workers, making it
+  # 4*4=20 workers in total. Memory usage depends on the actual number of resources reconciles in parallel and is not allocated upfront.
+  maxConcurrentReconciles: 1
+
   # Create operator service account and roles
   # if false, then templates/operator-roles.yaml is excluded
   createOperatorServiceAccount: true
@@ -63,9 +73,15 @@ operator:
   additionalArguments: []
 
   webhook:
+    # Controls whether the helm chart will install cluster role allowing to create ValidatingWebhookConfiguration. Default: true.
+    # Without the permissions, the operator will log errors when trying to configure admission webhooks, but will work correctly nonetheless.
+    installClusterRole: true
+
     # registerConfiguration setting (default: true) controls if the operator should automatically register ValidatingWebhookConfiguration and if required for it cluster-wide roles should be installed.
+    # DO NOT disable this setting if installing via helm. This setting is used for OLM installations.
     #
     # Setting false:
+    #  - This setting is intended to be used ONLY when the operator is installed via OLM. Do not use it otherwise as the operator won't start due to missing webhook server certificates, which OLM provides automatically.
     #  - Adds env var MDB_WEBHOOK_REGISTER_CONFIGURATION=false to the operator deployment.
     #  - ClusterRole and ClusterRoleBinding required to manage ValidatingWebhookConfigurations will not be installed
     #  - The operator will not create ValidatingWebhookConfigurations upon startup.
@@ -74,19 +90,19 @@ operator:
     #
     # Setting true:
     #  - It's the default setting, behaviour of the operator w.r.t. webhook configuration is the same as before.
-    #  - operator-webhook service will be created by the operator
+    #  - operator-webhook service will be created by the operator.
     #  - ClusterRole and ClusterRoleBinding required to manage ValidatingWebhookConfigurations will be installed.
-    #  - ValidatingWebhookConfigurations will be managed by the operator (requires cluster permissions)
+    #  - ValidatingWebhookConfigurations will be managed by the operator.
     registerConfiguration: true
 
 ## Database
 database:
   name: mongodb-enterprise-database-ubi
-  version: 1.25.0
+  version: 1.26.0
 
 initDatabase:
   name: mongodb-enterprise-init-database-ubi
-  version: 1.25.0
+  version: 1.26.0
 
 ## Ops Manager
 opsManager:
@@ -94,12 +110,12 @@ opsManager:
 
 initOpsManager:
   name: mongodb-enterprise-init-ops-manager-ubi
-  version: 1.25.0
+  version: 1.26.0
 
 ## Application Database
 initAppDb:
   name: mongodb-enterprise-init-appdb-ubi
-  version: 1.25.0
+  version: 1.26.0
 
 agent:
   name: mongodb-agent-ubi


### PR DESCRIPTION
## Kubernetes Enterprise Operator Release 1.26.0


This release patch has been created and it should be reviewed now.


You can add new commits to this patch if needed. After changes have
been reviewed, merge this PR for PCT to continue the release process.