### PR TITLE
Use new agent version, change default mongodb repo and set default imageType to ubi8

### DIFF
--- a/charts/community-operator/templates/operator.yaml
+++ b/charts/community-operator/templates/operator.yaml
@@ -67,6 +67,8 @@ spec:
               value: {{ .Values.mongodb.name }}
             - name: MONGODB_REPO_URL
               value: {{ .Values.mongodb.repo }}
+            - name: MDB_IMAGE_TYPE
+              value: {{ .Values.mongodb.imageType }}
           image: {{ .Values.registry.operator }}/{{ .Values.operator.operatorImageName }}:{{ .Values.operator.version }}
           imagePullPolicy: {{ .Values.registry.pullPolicy}}
           name: {{ .Values.operator.deploymentName }}

--- a/charts/community-operator/values.yaml
+++ b/charts/community-operator/values.yaml
@@ -62,7 +62,7 @@ database:
 
 agent:
   name: mongodb-agent-ubi
-  version: 107.0.1.8507-1
+  version: 107.0.7.8596-1
 versionUpgradeHook:
   name: mongodb-kubernetes-operator-version-upgrade-post-start-hook
   version: 1.0.8
@@ -70,8 +70,9 @@ readinessProbe:
   name: mongodb-kubernetes-readinessprobe
   version: 1.0.19
 mongodb:
-  name: mongo
-  repo: docker.io
+  name: mongodb-community-server
+  repo: docker.io/mongodb
+  imageType: ubi8
 
 registry:
   agent: quay.io/mongodb


### PR DESCRIPTION
This Pull request will:
- Change the `agent` version to a supported vesrion
- Set default `repo` to the official community server image. 
- Explicitly set the `imageType` to `ubi8`

### All Submissions:

* [x] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
