### PR TITLE
CLOUDP-258469 - add retries for chart releaser

### DIFF
--- a/.github/actions/releaser/cr.sh
+++ b/.github/actions/releaser/cr.sh
@@ -100,7 +100,7 @@ check_charts_released() {
             fi
             echo "Retrying in ${delay} seconds... ($((i+1))/$retries)"
             sleep "${delay}"
-            helm repo update mongodb
+            update_helm_repo
         done
 
         if [ "$released" = false ]; then
@@ -130,9 +130,13 @@ read_chart_version() {
     awk '/^version: /{print $2}' "$chart_path/Chart.yaml"
 }
 
+update_helm_repo(){
+    helm repo update mongodb
+}
+
 prepare_helm_repo() {
     helm repo add mongodb https://mongodb.github.io/helm-charts
-    helm repo update mongodb
+    update_helm_repo
 }
 
 chart_released() {

--- a/.github/actions/releaser/cr.sh
+++ b/.github/actions/releaser/cr.sh
@@ -77,7 +77,7 @@ check_charts_released() {
     local folders=("$@")
     local unreleased_charts=()
     local retries=5
-    local delay=10
+    local delay=5
 
     prepare_helm_repo
 

--- a/.github/actions/releaser/cr.sh
+++ b/.github/actions/releaser/cr.sh
@@ -100,6 +100,7 @@ check_charts_released() {
             fi
             echo "Retrying in ${delay} seconds... ($((i+1))/$retries)"
             sleep "${delay}"
+            helm repo update mongodb
         done
 
         if [ "$released" = false ]; then


### PR DESCRIPTION
The added chart checker fails to verify whether a chart has been released, it seems that sometimes it did succeed though. 
Which indicates that the helm repo might need some time until it reflects the actual updated state