### PR TITLE
Fix Helm Chart check retries

### DIFF
--- a/.github/actions/releaser/cr.sh
+++ b/.github/actions/releaser/cr.sh
@@ -91,7 +91,7 @@ check_charts_released() {
         chart_version=$(read_chart_version "${charts_dir}/${folder}")
         echo "Checking if \"$charts_dir/$folder\" has been released to the repo"
 
-        if ! check_chart_version_released; then
+        if ! check_chart_version_released "${chart_name}" "${chart_version}"; then
             unreleased_charts+=("$chart_name")
         fi
     done


### PR DESCRIPTION
I tried to reset the repo, to enforce update. I also doubled the pause in every retry.

The retry is now isolated to its own function and that together with SKIP_EXECUTION on the script allows for easy local testing.

cc @nammn 

### All Submissions:

* [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
