### PR TITLE
Fixed AKO Roles for multiple namespaces

### DIFF
--- a/charts/atlas-operator/templates/roles.yaml
+++ b/charts/atlas-operator/templates/roles.yaml
@@ -14,7 +14,7 @@ metadata:
   labels:
   {{- include "mongodb-atlas-operator.labels" $ | nindent 4 }}
 rules:
-{{- range (.Files.Lines "rbac.yaml") }}
+{{- range ($.Files.Lines "rbac.yaml") }}
   {{ . -}}
 {{- end }}
 ---


### PR DESCRIPTION
### All Submissions:

Fixed an error when Helm couldn't render RBAC permissions for Atlas Operator `Roles`

* [ ] Have you opened an Issue before filing this PR?
* [ ] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
