### PR TITLE
CLOUDP-281382: Wait more for chart release verification

### DIFF
--- a/.github/actions/releaser/cr.sh
+++ b/.github/actions/releaser/cr.sh
@@ -111,17 +111,17 @@ check_charts_released() {
 check_chart_version_released() {
     local chart_name=$1
     local chart_version=$2
-    local retries=5
-    local delay=1
+    local retries=30
+    local pause=10
+
+    echo "Checking helm chart ${chart_name} was released for version ${chart_version}"
     for ((i=0; i<retries; i++)); do
+        update_helm_repo
         if chart_released "${chart_name}" "${chart_version}"; then
             return 0
         fi
-        echo "$(date -u --iso-8601=seconds): Retrying in ${delay} seconds... ($((i+1))/$retries)"
-        sleep "${delay}"
-        delay=$((delay*2))
-        echo "$(date -u --iso-8601=seconds): Retrying..."
-        reset_helm_repo
+        echo "Retrying to check on ${chart_name}:${chart_version} in ${pause} seconds..."
+        sleep "${pause}"
     done
     return 1
 }


### PR DESCRIPTION
The helm chart release takes around a minute to happen as it depends on a `pages-build-deployment` to complete for the new helm index to be published.

---
✅ [Tested in fork repo](https://github.com/josvazg/helm-charts/actions/runs/11614918783/job/32344214812)

### All Submissions:

* [X] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
