### PR TITLE
CLOUDP-299771: atlas-deployment: add support for flex

### DIFF
--- a/charts/atlas-deployment/templates/atlas-deployment.yaml
+++ b/charts/atlas-deployment/templates/atlas-deployment.yaml
@@ -5,10 +5,10 @@ kind: AtlasDeployment
 metadata:
   {{- if .serverlessSpec }}
   name: {{ .serverlessSpec.name }}
-  {{- else if .advancedDeploymentSpec }}
-  name: {{ .advancedDeploymentSpec.name }}
   {{- else if .deploymentSpec }}
   name: {{ .deploymentSpec.name }}
+  {{- else if .flexSpec }}
+  name: {{ .flexSpec.name }}
   {{- end }}
   labels:
     {{- include "atlas-deployment.labels" $ | nindent 4 }}
@@ -27,6 +27,10 @@ spec:
   {{- if .serverlessSpec}}
   serverlessSpec:
   {{- toYaml .serverlessSpec | nindent 4}}
+  {{- end }}
+  {{- if .flexSpec}}
+  flexSpec:
+  {{- toYaml .flexSpec | nindent 4}}
   {{- end }}
 {{- end }}
 

--- a/charts/atlas-deployment/values.yaml
+++ b/charts/atlas-deployment/values.yaml
@@ -36,7 +36,7 @@ project:
     - ipAddress: "0.0.0.0"
       comment: "REMOVE ME"
 
-# include either deploymentSpec or serverlessSpec
+# include either deploymentSpec, serverlessSpec, or flexSpec
 # see https://www.mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Clusters/operation/createCluster for
 # options for creating advanced clusters.
 
@@ -103,6 +103,14 @@ deployments:
 #        providerName: SERVERLESS
 #        backingProviderName: AWS
 #        regionName: US_EAST_1
+
+# Configure a Flex Instance
+# https://www.mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Serverless-Instances/operation/createServerlessInstance
+# - flexSpec:
+#     name: flex-instance
+#     providerSettings:
+#       backingProviderName: AWS
+#       regionName: US_EAST_1
 
 users:
   - username: admin-user


### PR DESCRIPTION
Currently, flex deployments cannot be configured using our helm templates. This fixes it.

### All Submissions:

* [ ] Have you opened an Issue before filing this PR?
* [ ] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
