### PR TITLE
/bump helm chart version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@v1
         with:
-          version: v3.7.0
+          version: v3.17.1
 
       - uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
### Summary
- in meko we use 3.17, as it matches our kubernetes version support: https://helm.sh/docs/topics/version_skew/
```
1.32.x - 1.29.x
```

### All Submissions:

* [x] Have you opened an Issue before filing this PR?
* [x] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
