### PR TITLE
CLOUDP-347686: Fix AKO helm chart versioning

### DIFF
--- a/.github/workflows/post-atlas-operator-release.yaml
+++ b/.github/workflows/post-atlas-operator-release.yaml
@@ -37,13 +37,12 @@ jobs:
           VERSION=${{ github.event.inputs.version }}
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           cd helm/helm-charts/charts/atlas-operator-crds
-          sed -i -r 's/version:....../version: '"$VERSION"'/g' Chart.yaml
-          sed -i -r 's/appVersion:....../appVersion: '"$VERSION"'/g' Chart.yaml
+          sed -i -r 's/version:.*/version: '"$VERSION"'/g' Chart.yaml
+          sed -i -r 's/appVersion:.*/appVersion: '"$VERSION"'/g' Chart.yaml
           cd ..
           cd atlas-operator
-          sed -i -r 's/version:.\x22.....\x22/version: \x22'"$VERSION"'\x22/g' Chart.yaml
-          sed -i -r 's/version:......$/version: '"$VERSION"'/g' Chart.yaml
-          sed -i -r 's/appVersion:....../appVersion: '"$VERSION"'/g' Chart.yaml
+          sed -i -r 's/version:.*$/version: '"$VERSION"'/g' Chart.yaml
+          sed -i -r 's/appVersion:.*/appVersion: '"$VERSION"'/g' Chart.yaml
           cd ..
       - name: Set branch name
         id: git-config


### PR DESCRIPTION
Fix a quirk in the `sed` used in AKO releases that was causing double zeroes for the patch number (e.g. `2.11.00` instead of `2.11.0`)

### All Submissions:

* [ ] Have you opened an Issue before filing this PR?
* [ ] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
