### PR TITLE
Add resource configuration for MongoDB init containers

### DIFF
--- a/charts/community-operator/templates/mongodbcommunity_cr_with_tls.yaml
+++ b/charts/community-operator/templates/mongodbcommunity_cr_with_tls.yaml
@@ -120,6 +120,17 @@ spec:
   members: {{ .Values.resource.members }}
   type: ReplicaSet
   version: {{ .Values.resource.version }}
+  statefulSetConfiguration:
+    spec:
+      template:
+        spec:
+          initContainers:
+            - name: mongod-posthook
+              resources:
+                {{- toYaml .Values.resource.initContainers.resources | nindent 16 }}
+            - name: mongodb-agent-readinessprobe
+              resources:
+                {{- toYaml .Values.resource.initContainers.resources | nindent 16 }}
   security:
     tls:
       enabled: {{ .Values.resource.tls.enabled }}

--- a/charts/community-operator/values.yaml
+++ b/charts/community-operator/values.yaml
@@ -29,6 +29,16 @@ operator:
       cpu: 500m
       memory: 200Mi
 
+  # Resources for init containers
+  initContainers:
+    resources:
+      limits:
+        cpu: 100m
+        memory: 128Mi
+      requests:
+        cpu: 50m
+        memory: 64Mi
+
   # PriorityClass configuration for operator
   # ref: https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#priorityclass
   priorityClassName: ''
@@ -96,6 +106,15 @@ resource:
   name: mongodb-replica-set
   version: 4.4.0
   members: 3
+  # Resources for MongoDB pod init containers
+  initContainers:
+    resources:
+      limits:
+        cpu: 100m
+        memory: 128Mi
+      requests:
+        cpu: 50m
+        memory: 64Mi
   tls:
     enabled: false
 


### PR DESCRIPTION
Add resource limits and requests for MongoDB pod init containers (mongod-posthook and mongodb-agent-readinessprobe) in the community operator chart. Configure default values of 50m/100m CPU and 64Mi/128Mi memory for requests/limits respectively.

### All Submissions:

* [x] Have you opened an Issue before filing this PR?
* [x] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
