### PR TITLE
fix: add minimum permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/check-released.yml
+++ b/.github/workflows/check-released.yml
@@ -11,6 +11,9 @@ on:
         default: ""
         required: false
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,6 +5,9 @@ on:
     paths:
       - 'charts/**'
 
+permissions:
+  contents: read
+
 jobs:
   lint-chart:
     runs-on: ubuntu-latest

--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -6,6 +6,10 @@ on:
   schedule:
     - cron: "30 1 * * *"
 
+permissions:
+  issues: write
+  pull-requests: write
+
 jobs:
   stale:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -3,6 +3,9 @@ name: Bashscript linter
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   shellcheck:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,6 +24,9 @@ on:
         default: ""
         required: false
 
+permissions:
+  contents: write
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Add explicit permissions blocks to all workflows flagged by CodeQL

alerts #1-#6. Read-only workflows get contents:read, the chart

releaser gets contents:write, and the stale bot gets issues:write

and pull-requests:write.

